### PR TITLE
Sample from bam

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -79,8 +79,8 @@ get_unmodified_base <- function(b) {
 #'
 #' @noRd
 #' @keywords internal
-read_modbam_cpp <- function(inname_str, regions, modbase, verbose = FALSE) {
-    .Call(`_footprintR_read_modbam_cpp`, inname_str, regions, modbase, verbose)
+read_modbam_cpp <- function(inname_str, regions, n_alns_to_sample, modbase, verbose = FALSE) {
+    .Call(`_footprintR_read_modbam_cpp`, inname_str, regions, n_alns_to_sample, modbase, verbose)
 }
 
 #' @title Sample Entropy of Time series signal

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -48,6 +48,11 @@ get_unmodified_base <- function(b) {
 #' @param regions Character vector specifying the region(s) for which
 #'     to extract overlapping reads, in the form \code{"chr:start-end"}
 #' @param modbase Character scalar defining the modified base to extract.
+#' @param n_alns_to_sample Integer defining the number of alignments
+#'     to randomly sample.
+#' @param tnames_for_sampling String vector with target names (chromosomes)
+#'     from which to sample \code{n_alns_to_sample} alignments. Ignored if
+#'     \code{n_alns_to_sample = 0}.
 #' @param verbose Logical scalar. If \code{TRUE}, report on progress.
 #'
 #' @return A named list with elements \code{"read_id"}, \code{qscore},
@@ -79,8 +84,8 @@ get_unmodified_base <- function(b) {
 #'
 #' @noRd
 #' @keywords internal
-read_modbam_cpp <- function(inname_str, regions, n_alns_to_sample, modbase, verbose = FALSE) {
-    .Call(`_footprintR_read_modbam_cpp`, inname_str, regions, n_alns_to_sample, modbase, verbose)
+read_modbam_cpp <- function(inname_str, regions, modbase, n_alns_to_sample, tnames_for_sampling, verbose = FALSE) {
+    .Call(`_footprintR_read_modbam_cpp`, inname_str, regions, modbase, n_alns_to_sample, tnames_for_sampling, verbose)
 }
 
 #' @title Sample Entropy of Time series signal

--- a/man/readModBam.Rd
+++ b/man/readModBam.Rd
@@ -6,7 +6,8 @@
 \usage{
 readModBam(
   bamfiles,
-  regions,
+  regions = NULL,
+  nAlnsToSample = 0,
   modbase,
   seqinfo = NULL,
   ncpu = 1L,
@@ -26,7 +27,13 @@ genomic regions to extract the reads from. Alternatively, regions can be
 specified as a character vector (e.g. "chr1:1200-1300") that can be
 coerced into a \code{GRanges} object. Note that the reads are not
 trimmed to the boundaries of the specified ranges. As a result, returned
-positions will typically extend out of the specified regions.}
+positions will typically extend out of the specified regions.
+If \code{nAlnsToSample} is set to a non-zero value, \code{regions} is
+ignored.}
+
+\item{nAlnsToSample}{A numeric scalar. If non-zero, \code{regions} is ignored
+and \code{nAlnsToSample} randomly selected alignments are read from each
+of the \code{bamfiles}.}
 
 \item{modbase}{Character vector defining the modified base for each sample.
 If \code{modbase} is a named vector, the names should correspond to

--- a/man/readModBam.Rd
+++ b/man/readModBam.Rd
@@ -7,8 +7,9 @@
 readModBam(
   bamfiles,
   regions = NULL,
-  nAlnsToSample = 0,
   modbase,
+  nAlnsToSample = 0,
+  seqnamesToSampleFrom = "chr19",
   seqinfo = NULL,
   ncpu = 1L,
   verbose = FALSE
@@ -31,16 +32,20 @@ positions will typically extend out of the specified regions.
 If \code{nAlnsToSample} is set to a non-zero value, \code{regions} is
 ignored.}
 
-\item{nAlnsToSample}{A numeric scalar. If non-zero, \code{regions} is ignored
-and \code{nAlnsToSample} randomly selected alignments are read from each
-of the \code{bamfiles}.}
-
 \item{modbase}{Character vector defining the modified base for each sample.
 If \code{modbase} is a named vector, the names should correspond to
 the names of \code{bamfiles}. Otherwise, it will be assumed that the
 elements are in the same order as the files in \code{bamfiles}. If
 \code{modbase} has length 1, the same modified base will be used for
 all samples.}
+
+\item{nAlnsToSample}{A numeric scalar. If non-zero, \code{regions} is ignored
+and approximately \code{nAlnsToSample} randomly selected alignments on
+\code{seqnamesToSampleFrom} are read from each of the \code{bamfiles}.}
+
+\item{seqnamesToSampleFrom}{A character vector with one or several sequence
+names (chromosomes) from which to sample alignments from (only used if
+\code{nAlnsToSample} is greater than zero).}
 
 \item{seqinfo}{\code{NULL} or a \code{\link[GenomeInfoDb]{Seqinfo}} object
 containing information about the set of genomic sequences (chromosomes).

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -46,17 +46,18 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_modbam_cpp
-Rcpp::List read_modbam_cpp(std::string inname_str, std::vector<std::string> regions, int n_alns_to_sample, char modbase, bool verbose);
-RcppExport SEXP _footprintR_read_modbam_cpp(SEXP inname_strSEXP, SEXP regionsSEXP, SEXP n_alns_to_sampleSEXP, SEXP modbaseSEXP, SEXP verboseSEXP) {
+Rcpp::List read_modbam_cpp(std::string inname_str, std::vector<std::string> regions, char modbase, int n_alns_to_sample, std::vector<std::string> tnames_for_sampling, bool verbose);
+RcppExport SEXP _footprintR_read_modbam_cpp(SEXP inname_strSEXP, SEXP regionsSEXP, SEXP modbaseSEXP, SEXP n_alns_to_sampleSEXP, SEXP tnames_for_samplingSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type inname_str(inname_strSEXP);
     Rcpp::traits::input_parameter< std::vector<std::string> >::type regions(regionsSEXP);
-    Rcpp::traits::input_parameter< int >::type n_alns_to_sample(n_alns_to_sampleSEXP);
     Rcpp::traits::input_parameter< char >::type modbase(modbaseSEXP);
+    Rcpp::traits::input_parameter< int >::type n_alns_to_sample(n_alns_to_sampleSEXP);
+    Rcpp::traits::input_parameter< std::vector<std::string> >::type tnames_for_sampling(tnames_for_samplingSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
-    rcpp_result_gen = Rcpp::wrap(read_modbam_cpp(inname_str, regions, n_alns_to_sample, modbase, verbose));
+    rcpp_result_gen = Rcpp::wrap(read_modbam_cpp(inname_str, regions, modbase, n_alns_to_sample, tnames_for_sampling, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -78,7 +79,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_footprintR_calcAndCountDist", (DL_FUNC) &_footprintR_calcAndCountDist, 3},
     {"_footprintR_complement", (DL_FUNC) &_footprintR_complement, 1},
     {"_footprintR_get_unmodified_base", (DL_FUNC) &_footprintR_get_unmodified_base, 1},
-    {"_footprintR_read_modbam_cpp", (DL_FUNC) &_footprintR_read_modbam_cpp, 5},
+    {"_footprintR_read_modbam_cpp", (DL_FUNC) &_footprintR_read_modbam_cpp, 6},
     {"_footprintR_sampleEntropy", (DL_FUNC) &_footprintR_sampleEntropy, 3},
     {NULL, NULL, 0}
 };

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -46,16 +46,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // read_modbam_cpp
-Rcpp::List read_modbam_cpp(std::string inname_str, std::vector<std::string> regions, char modbase, bool verbose);
-RcppExport SEXP _footprintR_read_modbam_cpp(SEXP inname_strSEXP, SEXP regionsSEXP, SEXP modbaseSEXP, SEXP verboseSEXP) {
+Rcpp::List read_modbam_cpp(std::string inname_str, std::vector<std::string> regions, int n_alns_to_sample, char modbase, bool verbose);
+RcppExport SEXP _footprintR_read_modbam_cpp(SEXP inname_strSEXP, SEXP regionsSEXP, SEXP n_alns_to_sampleSEXP, SEXP modbaseSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type inname_str(inname_strSEXP);
     Rcpp::traits::input_parameter< std::vector<std::string> >::type regions(regionsSEXP);
+    Rcpp::traits::input_parameter< int >::type n_alns_to_sample(n_alns_to_sampleSEXP);
     Rcpp::traits::input_parameter< char >::type modbase(modbaseSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
-    rcpp_result_gen = Rcpp::wrap(read_modbam_cpp(inname_str, regions, modbase, verbose));
+    rcpp_result_gen = Rcpp::wrap(read_modbam_cpp(inname_str, regions, n_alns_to_sample, modbase, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -77,7 +78,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_footprintR_calcAndCountDist", (DL_FUNC) &_footprintR_calcAndCountDist, 3},
     {"_footprintR_complement", (DL_FUNC) &_footprintR_complement, 1},
     {"_footprintR_get_unmodified_base", (DL_FUNC) &_footprintR_get_unmodified_base, 1},
-    {"_footprintR_read_modbam_cpp", (DL_FUNC) &_footprintR_read_modbam_cpp, 4},
+    {"_footprintR_read_modbam_cpp", (DL_FUNC) &_footprintR_read_modbam_cpp, 5},
     {"_footprintR_sampleEntropy", (DL_FUNC) &_footprintR_sampleEntropy, 3},
     {NULL, NULL, 0}
 };

--- a/tests/testthat/test-readModBam.R
+++ b/tests/testthat/test-readModBam.R
@@ -40,8 +40,10 @@ test_that("readModBam works", {
     expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "a", "error"),
                  "must be of class 'numeric'")
     expect_error(
-        expect_warning(readModBam(modbamfiles, "chr1:6940000-6955000", "a", 10, "error"),
-                       "Ignoring `regions`"),
+        expect_warning(
+            expect_warning(readModBam(modbamfiles, "chr1:6940000-6955000", "a", 10, "error"),
+                           "Ignoring `regions`"),
+            "Ignoring unknown target name"),
         "Cannot sample 10 alignments from a total of 0")
     expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "a", 0, "chr1", "error"),
                  "`seqinfo` must be `NULL`, a `Seqinfo` object or")
@@ -110,7 +112,7 @@ test_that("readModBam works", {
                                                     verbose = TRUE),
                                 "extracting base modifications"),
                             "opening input file"),
-                        "sampling 50% of alignments"),
+                        "sampling alignments with probability 0.5"),
                     "reading alignments overlapping"),
                 "removed 2006 unaligned"),
             "finding unique genomic"),

--- a/tests/testthat/test-readModBam.R
+++ b/tests/testthat/test-readModBam.R
@@ -21,21 +21,23 @@ test_that("readModBam works", {
     names(extractfiles) <- names(modbamfiles)
 
     # invalid arguments
-    expect_error(readModBam("error", "chr1:6940000-6955000", "a"),
+    expect_error(readModBam("error", "chr1:6940000-6955000", 0, "a"),
                  "not all `bamfiles` exist")
     expect_error(readModBam(structure(unname(modbamfiles), names = c("s1", "s1")),
-                            "chr1:6940000-6955000", "a"),
+                            "chr1:6940000-6955000", 0, "a"),
                  "are not unique")
-    expect_error(readModBam(modbamfiles, "error", "a"),
+    expect_error(readModBam(modbamfiles, "error", 0, "a"),
                  "GRanges object must contain")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "Z"),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", -1, "a"),
+                 "must be within .0,Inf.")
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0, "Z"),
                  "invalid `modbase` values")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", c("a", "a", "a")),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0, c("a", "a", "a")),
                  "must have length")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000",
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0,
                             c(sample1 = "a", sample3 = "a")),
                  "names of `modbase` and `bamfiles` don't agree")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "a", "error"),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0, "a", "error"),
                  "`seqinfo` must be `NULL`, a `Seqinfo` object or")
 
     # expected results
@@ -49,34 +51,41 @@ test_that("readModBam works", {
         expect_message(expect_message(expect_message(expect_message(
             expect_message(
                 se1 <- readModBam(bamfiles = modbamfiles,
-                                  regions = reg1,
+                                  regions = reg1, nAlnsToSample = 0,
                                   modbase = "a", verbose = TRUE)
     )))))))))
     se2 <- readModBam(bamfiles = unname(modbamfiles),
                       regions = reg2,
+                      nAlnsToSample = 0,
                       modbase = "a",
                       verbose = FALSE)
     se3 <- readModBam(bamfiles = modbamfiles,
                       regions = reg3,
+                      nAlnsToSample = 0,
                       modbase = "a",
                       verbose = FALSE)
     se4 <- readModBam(bamfiles = modbamfiles,
                       regions = reg4,
+                      nAlnsToSample = 0,
                       modbase = c("a", "m"),
                       verbose = FALSE)
     se5a <- readModBam(bamfiles = modbamfiles[1],
                        regions = reg5[1],
+                       nAlnsToSample = 0,
                        modbase = "a",
                        verbose = FALSE)
     se5b <- readModBam(bamfiles = modbamfiles[1],
                        regions = reg5[1:2],
+                       nAlnsToSample = 0,
                        modbase = "a",
                        verbose = FALSE)
-    aln5a <- scanBam(file = modbamfiles[1], param = ScanBamParam(
+    aln5a <- Rsamtools::scanBam(file = modbamfiles[1],
+                                param = Rsamtools::ScanBamParam(
         what = "qname",
         which = GRanges(reg5[1])
     ))
-    aln5b <- scanBam(file = modbamfiles[1], param = ScanBamParam(
+    aln5b <- Rsamtools::scanBam(file = modbamfiles[1],
+                                param = Rsamtools::ScanBamParam(
         what = "qname",
         which = GRanges(reg5[1:2])
     ))

--- a/tests/testthat/test-readModBam.R
+++ b/tests/testthat/test-readModBam.R
@@ -21,23 +21,29 @@ test_that("readModBam works", {
     names(extractfiles) <- names(modbamfiles)
 
     # invalid arguments
-    expect_error(readModBam("error", "chr1:6940000-6955000", 0, "a"),
+    expect_error(readModBam("error", "chr1:6940000-6955000", "a", 0),
                  "not all `bamfiles` exist")
     expect_error(readModBam(structure(unname(modbamfiles), names = c("s1", "s1")),
-                            "chr1:6940000-6955000", 0, "a"),
+                            "chr1:6940000-6955000", "a", 0),
                  "are not unique")
-    expect_error(readModBam(modbamfiles, "error", 0, "a"),
+    expect_error(readModBam(modbamfiles, "error", "a", 0),
                  "GRanges object must contain")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", -1, "a"),
-                 "must be within .0,Inf.")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0, "Z"),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "Z", 0),
                  "invalid `modbase` values")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0, c("a", "a", "a")),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", c("a", "a", "a"), 0),
                  "must have length")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0,
-                            c(sample1 = "a", sample3 = "a")),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000",
+                            c(sample1 = "a", sample3 = "a"), 0),
                  "names of `modbase` and `bamfiles` don't agree")
-    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", 0, "a", "error"),
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "a", -1),
+                 "must be within .0,Inf.")
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "a", "error"),
+                 "must be of class 'numeric'")
+    expect_error(
+        expect_warning(readModBam(modbamfiles, "chr1:6940000-6955000", "a", 10, "error"),
+                       "Ignoring `regions`"),
+        "Cannot sample 10 alignments from a total of 0")
+    expect_error(readModBam(modbamfiles, "chr1:6940000-6955000", "a", 0, "chr1", "error"),
                  "`seqinfo` must be `NULL`, a `Seqinfo` object or")
 
     # expected results
@@ -50,34 +56,34 @@ test_that("readModBam works", {
     expect_message(expect_message(expect_message(expect_message(
         expect_message(expect_message(expect_message(expect_message(
             expect_message(
-                se1 <- readModBam(bamfiles = modbamfiles,
-                                  regions = reg1, nAlnsToSample = 0,
-                                  modbase = "a", verbose = TRUE)
+                se1 <- readModBam(bamfiles = modbamfiles, regions = reg1,
+                                  modbase = "a", nAlnsToSample = 0,
+                                  seqnamesToSampleFrom = "chr1", verbose = TRUE)
     )))))))))
     se2 <- readModBam(bamfiles = unname(modbamfiles),
                       regions = reg2,
-                      nAlnsToSample = 0,
                       modbase = "a",
+                      nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                       verbose = FALSE)
     se3 <- readModBam(bamfiles = modbamfiles,
                       regions = reg3,
-                      nAlnsToSample = 0,
                       modbase = "a",
+                      nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                       verbose = FALSE)
     se4 <- readModBam(bamfiles = modbamfiles,
                       regions = reg4,
-                      nAlnsToSample = 0,
                       modbase = c("a", "m"),
+                      nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                       verbose = FALSE)
     se5a <- readModBam(bamfiles = modbamfiles[1],
                        regions = reg5[1],
-                       nAlnsToSample = 0,
                        modbase = "a",
+                       nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                        verbose = FALSE)
     se5b <- readModBam(bamfiles = modbamfiles[1],
                        regions = reg5[1:2],
-                       nAlnsToSample = 0,
                        modbase = "a",
+                       nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                        verbose = FALSE)
     aln5a <- Rsamtools::scanBam(file = modbamfiles[1],
                                 param = Rsamtools::ScanBamParam(
@@ -89,6 +95,32 @@ test_that("readModBam works", {
         what = "qname",
         which = GRanges(reg5[1:2])
     ))
+    set.seed(55L)
+    expect_message(
+        expect_message(
+            expect_message(
+                expect_message(
+                    expect_message(
+                        expect_message(
+                            expect_message(
+                                se6a  <- readModBam(bamfiles = modbamfiles[1],
+                                                    regions = NULL,
+                                                    modbase = "a",
+                                                    nAlnsToSample = 5, seqnamesToSampleFrom = "chr1",
+                                                    verbose = TRUE),
+                                "extracting base modifications"),
+                            "opening input file"),
+                        "sampling 50% of alignments"),
+                    "reading alignments overlapping"),
+                "removed 2006 unaligned"),
+            "finding unique genomic"),
+        "collapsed 16095 positions to 6852")
+    set.seed(55L)
+    se6b  <- readModBam(bamfiles = modbamfiles[1],
+                        regions = NULL,
+                        modbase = "a",
+                        nAlnsToSample = 5, seqnamesToSampleFrom = "chr1",
+                        verbose = FALSE)
 
     # ... structure
     expect_s4_class(se1, "RangedSummarizedExperiment")
@@ -97,6 +129,8 @@ test_that("readModBam works", {
     expect_s4_class(se4, "RangedSummarizedExperiment")
     expect_s4_class(se5a, "RangedSummarizedExperiment")
     expect_s4_class(se5b, "RangedSummarizedExperiment")
+    expect_s4_class(se6a, "RangedSummarizedExperiment")
+    expect_s4_class(se6b, "RangedSummarizedExperiment")
 
     expect_s4_class(rowRanges(se1), "GPos")
     expect_s4_class(rowRanges(se2), "GPos")
@@ -104,6 +138,8 @@ test_that("readModBam works", {
     expect_s4_class(rowRanges(se4), "GPos")
     expect_s4_class(rowRanges(se5a), "GPos")
     expect_s4_class(rowRanges(se5b), "GPos")
+    expect_s4_class(rowRanges(se6a), "GPos")
+    expect_s4_class(rowRanges(se6b), "GPos")
 
     expected_coldata_names <- c("sample", "modbase", "n_reads", "qscore")
     expect_identical(colnames(colData(se1)), expected_coldata_names)
@@ -112,6 +148,8 @@ test_that("readModBam works", {
     expect_identical(colnames(colData(se4)), expected_coldata_names)
     expect_identical(colnames(colData(se5a)), expected_coldata_names)
     expect_identical(colnames(colData(se5b)), expected_coldata_names)
+    expect_identical(colnames(colData(se6a)), expected_coldata_names)
+    expect_identical(colnames(colData(se6b)), expected_coldata_names)
 
     expect_identical(se1$sample, names(modbamfiles))
     expect_identical(se2$sample, c("s1", "s2"))
@@ -119,6 +157,8 @@ test_that("readModBam works", {
     expect_identical(se4$sample, names(modbamfiles))
     expect_identical(se5a$sample, names(modbamfiles)[1])
     expect_identical(se5b$sample, names(modbamfiles)[1])
+    expect_identical(se6a$sample, names(modbamfiles)[1])
+    expect_identical(se6b$sample, names(modbamfiles)[1])
 
     expect_identical(assayNames(se1), "mod_prob")
     expect_identical(assayNames(se2), "mod_prob")
@@ -126,6 +166,8 @@ test_that("readModBam works", {
     expect_identical(assayNames(se4), "mod_prob")
     expect_identical(assayNames(se5a), "mod_prob")
     expect_identical(assayNames(se5b), "mod_prob")
+    expect_identical(assayNames(se6a), "mod_prob")
+    expect_identical(assayNames(se6b), "mod_prob")
 
     expect_s4_class(assay(se1, "mod_prob"), "DFrame")
     expect_s4_class(assay(se2, "mod_prob"), "DFrame")
@@ -133,6 +175,8 @@ test_that("readModBam works", {
     expect_s4_class(assay(se4, "mod_prob"), "DFrame")
     expect_s4_class(assay(se5a, "mod_prob"), "DFrame")
     expect_s4_class(assay(se5b, "mod_prob"), "DFrame")
+    expect_s4_class(assay(se6a, "mod_prob"), "DFrame")
+    expect_s4_class(assay(se6b, "mod_prob"), "DFrame")
 
     expect_s4_class(assay(se1, "mod_prob")[[1]], "NaMatrix")
     expect_s4_class(assay(se2, "mod_prob")[[1]], "NaMatrix")
@@ -140,6 +184,8 @@ test_that("readModBam works", {
     expect_s4_class(assay(se4, "mod_prob")[[1]], "NaMatrix")
     expect_s4_class(assay(se5a, "mod_prob")[[1]], "NaMatrix")
     expect_s4_class(assay(se5b, "mod_prob")[[1]], "NaMatrix")
+    expect_s4_class(assay(se6a, "mod_prob")[[1]], "NaMatrix")
+    expect_s4_class(assay(se6b, "mod_prob")[[1]], "NaMatrix")
 
     expect_equal(vapply(assay(se1, "mod_prob"), ncol, 0), se1$n_reads)
     expect_equal(vapply(assay(se2, "mod_prob"), ncol, 0), se2$n_reads)
@@ -147,6 +193,8 @@ test_that("readModBam works", {
     expect_equal(vapply(assay(se4, "mod_prob"), ncol, 0), se4$n_reads)
     expect_equal(vapply(assay(se5a, "mod_prob"), ncol, 0), se5a$n_reads)
     expect_equal(vapply(assay(se5b, "mod_prob"), ncol, 0), se5b$n_reads)
+    expect_equal(vapply(assay(se6a, "mod_prob"), ncol, 0), se6a$n_reads)
+    expect_equal(vapply(assay(se6b, "mod_prob"), ncol, 0), se6b$n_reads)
 
     # ... content se1
     expect_identical(unname(se1$n_reads), c(4L, 6L))
@@ -227,4 +275,8 @@ test_that("readModBam works", {
     expect_identical(idx, rownames(se5a))
     expect_identical(mp5a[idx, "sample1"][, paste0("sample1-", aln5a[[1]]$qname)],
                      mp5b[idx, "sample1"][, paste0("sample1-", aln5b[[1]]$qname)])
+
+    # ... content of se6a and se6b
+    expect_identical(se6a, se6b)
+    expect_identical(dim(assay(se6a)$sample1), c(6852L, 6L))
 })

--- a/tests/testthat/test-read_modbam_cpp.R
+++ b/tests/testthat/test-read_modbam_cpp.R
@@ -150,7 +150,10 @@ test_that("read_modbam_cpp works", {
                                     which = GRanges(c("chr1:6941000-6941001", "chr1:6928000-6928001"))
                                 ))
     set.seed(1L)
-    res7a <- read_modbam_cpp(modbamfile, "chr1", "a", 3, "chr1", FALSE)
+    expect_warning(
+        res7a <- read_modbam_cpp(modbamfile, "chr1", "a", 3, c("chr1", "error"), FALSE),
+        "Ignoring unknown target name"
+    )
     set.seed(1L)
     res7b <- read_modbam_cpp(modbamfile, "chr1", "a", 3, "chr1", FALSE)
     expect_message(

--- a/tests/testthat/test-read_modbam_cpp.R
+++ b/tests/testthat/test-read_modbam_cpp.R
@@ -61,12 +61,16 @@ test_that("read_modbam_cpp works", {
     ## invalid arguments
     ## -------------------------------------------------------------------------
     # ... non-existing bam file
-    expect_error(read_modbam_cpp("error", "chr1", "a", FALSE))
+    expect_error(read_modbam_cpp(inname_str = "error", regions = "chr1",
+                                 n_alns_to_sample = 0, modbase = "a",
+                                 verbose = FALSE))
 
     # ... no bam index
     tmpbam <- tempfile(fileext = ".bam")
     expect_true(file.copy(from = modbamfile, to = tmpbam))
-    expect_error(read_modbam_cpp(tmpbam, "chr1", "a", FALSE))
+    expect_error(read_modbam_cpp(inname_str = tmpbam, regions = "chr1",
+                                 n_alns_to_sample = 0, modbase = "a",
+                                 verbose = FALSE))
     unlink(tmpbam)
 
     # ... corrupted bam file
@@ -80,39 +84,52 @@ test_that("read_modbam_cpp works", {
     writeBin(data[seq.int(length(data) - 77)], con_out)
     close(con_out)
     expect_true(file.copy(from = paste0(modbamfile, ".bai"), to = tmpbai))
-    expect_error(read_modbam_cpp(tmpbam, "chr1", "a", FALSE))
+    expect_error(read_modbam_cpp(inname_str = tmpbam, regions = "chr1",
+                                 n_alns_to_sample = 0, modbase = "a",
+                                 verbose = FALSE))
     unlink(c(tmpbam, tmpbai))
 
     # ... requesting a region that is not contained in the bam header
-    expect_error(read_modbam_cpp(bam4, "chr2", "a"))
+    expect_error(read_modbam_cpp(inname_str = bam4, regions = "chr2",
+                                 n_alns_to_sample = 0, modbase = "a"))
 
     # ... MM/ML tags referring to position beyond read length
-    expect_error(read_modbam_cpp(bam7, "chr1", "a", FALSE))
+    expect_error(read_modbam_cpp(inname_str = bam7, regions = "chr1",
+                                 n_alns_to_sample = 0, modbase = "a",
+                                 verbose = FALSE))
 
     # ... too many modifications on a single base
-    expect_error(read_modbam_cpp(bam8, "chr1", "a", FALSE))
+    expect_error(read_modbam_cpp(inname_str = bam8, regions = "chr1",
+                                 n_alns_to_sample = 0, modbase = "a",
+                                 verbose = FALSE))
 
     ## expected results
     ## -------------------------------------------------------------------------
     # ... run read_modbam_cpp
     df <- read.delim(extractfile)
     expect_message(expect_message(expect_message(
-        res1 <- read_modbam_cpp(modbamfile, "chr1:6940000-6955000", "a", TRUE)
+        res1 <- read_modbam_cpp(inname_str = modbamfile,
+                                regions = "chr1:6940000-6955000",
+                                n_alns_to_sample = 0,
+                                modbase = "a",
+                                verbose = TRUE)
     )))
-    res2 <- read_modbam_cpp(modbamfile, "chr1:", "a", FALSE)
-    res3 <- read_modbam_cpp(modbamfile, c("chr1", "chr2"), "m", FALSE)
-    res4 <- read_modbam_cpp(bam4, "chr1", "a", FALSE)
-    res5 <- read_modbam_cpp(bam5, "chr1", "a", FALSE)
-    res6a <- read_modbam_cpp(modbamfile, "chr1:6941000-6941001", "a", FALSE)
-    res6b <- read_modbam_cpp(modbamfile, c("chr1:6941000-6941001", "chr1:6928000-6928001"), "a", FALSE)
-    aln6a <- scanBam(file = modbamfile, param = ScanBamParam(
-        what = "qname",
-        which = GRanges("chr1:6941000-6941001")
-    ))
-    aln6b <- scanBam(file = modbamfile, param = ScanBamParam(
-        what = "qname",
-        which = GRanges(c("chr1:6941000-6941001", "chr1:6928000-6928001"))
-    ))
+    res2 <- read_modbam_cpp(modbamfile, "chr1:", 0, "a", FALSE)
+    res3 <- read_modbam_cpp(modbamfile, c("chr1", "chr2"), 0, "m", FALSE)
+    res4 <- read_modbam_cpp(bam4, "chr1", 0, "a", FALSE)
+    res5 <- read_modbam_cpp(bam5, "chr1", 0, "a", FALSE)
+    res6a <- read_modbam_cpp(modbamfile, "chr1:6941000-6941001", 0, "a", FALSE)
+    res6b <- read_modbam_cpp(modbamfile, c("chr1:6941000-6941001", "chr1:6928000-6928001"), 0, "a", FALSE)
+    aln6a <- Rsamtools::scanBam(file = modbamfile,
+                                param = Rsamtools::ScanBamParam(
+                                    what = "qname",
+                                    which = GRanges("chr1:6941000-6941001")
+                                ))
+    aln6b <- Rsamtools::scanBam(file = modbamfile,
+                                param = Rsamtools::ScanBamParam(
+                                    what = "qname",
+                                    which = GRanges(c("chr1:6941000-6941001", "chr1:6928000-6928001"))
+                                ))
 
     # ... results structure
     expect_type(res1, "list")

--- a/tests/testthat/test-read_modbam_cpp.R
+++ b/tests/testthat/test-read_modbam_cpp.R
@@ -62,14 +62,16 @@ test_that("read_modbam_cpp works", {
     ## -------------------------------------------------------------------------
     # ... non-existing bam file
     expect_error(read_modbam_cpp(inname_str = "error", regions = "chr1",
-                                 n_alns_to_sample = 0, modbase = "a",
+                                 modbase = "a", n_alns_to_sample = 0,
+                                 tnames_for_sampling = "chr1",
                                  verbose = FALSE))
 
     # ... no bam index
     tmpbam <- tempfile(fileext = ".bam")
     expect_true(file.copy(from = modbamfile, to = tmpbam))
     expect_error(read_modbam_cpp(inname_str = tmpbam, regions = "chr1",
-                                 n_alns_to_sample = 0, modbase = "a",
+                                 modbase = "a", n_alns_to_sample = 0,
+                                 tnames_for_sampling = "chr1",
                                  verbose = FALSE))
     unlink(tmpbam)
 
@@ -85,22 +87,38 @@ test_that("read_modbam_cpp works", {
     close(con_out)
     expect_true(file.copy(from = paste0(modbamfile, ".bai"), to = tmpbai))
     expect_error(read_modbam_cpp(inname_str = tmpbam, regions = "chr1",
-                                 n_alns_to_sample = 0, modbase = "a",
+                                 modbase = "a", n_alns_to_sample = 0,
+                                 tnames_for_sampling = "chr1",
                                  verbose = FALSE))
     unlink(c(tmpbam, tmpbai))
 
     # ... requesting a region that is not contained in the bam header
     expect_error(read_modbam_cpp(inname_str = bam4, regions = "chr2",
-                                 n_alns_to_sample = 0, modbase = "a"))
+                                 modbase = "a", n_alns_to_sample = 0,
+                                 tnames_for_sampling = "chr1"))
 
     # ... MM/ML tags referring to position beyond read length
     expect_error(read_modbam_cpp(inname_str = bam7, regions = "chr1",
-                                 n_alns_to_sample = 0, modbase = "a",
+                                 modbase = "a", n_alns_to_sample = 0,
+                                 tnames_for_sampling = "chr1",
                                  verbose = FALSE))
 
     # ... too many modifications on a single base
     expect_error(read_modbam_cpp(inname_str = bam8, regions = "chr1",
-                                 n_alns_to_sample = 0, modbase = "a",
+                                 modbase = "a", n_alns_to_sample = 0,
+                                 tnames_for_sampling = "chr1",
+                                 verbose = FALSE))
+
+    # ... too many reads to sample
+    expect_error(read_modbam_cpp(inname_str = modbamfile, regions = "chr1",
+                                 modbase = "a", n_alns_to_sample = 11,
+                                 tnames_for_sampling = "chr1",
+                                 verbose = FALSE))
+
+    # ... sampling reads from a chromosome without alignments
+    expect_error(read_modbam_cpp(inname_str = modbamfile, regions = "chr1",
+                                 modbase = "a", n_alns_to_sample = 1,
+                                 tnames_for_sampling = "chr2",
                                  verbose = FALSE))
 
     ## expected results
@@ -110,16 +128,17 @@ test_that("read_modbam_cpp works", {
     expect_message(expect_message(expect_message(
         res1 <- read_modbam_cpp(inname_str = modbamfile,
                                 regions = "chr1:6940000-6955000",
-                                n_alns_to_sample = 0,
                                 modbase = "a",
+                                n_alns_to_sample = 0,
+                                tnames_for_sampling = "chr1",
                                 verbose = TRUE)
     )))
-    res2 <- read_modbam_cpp(modbamfile, "chr1:", 0, "a", FALSE)
-    res3 <- read_modbam_cpp(modbamfile, c("chr1", "chr2"), 0, "m", FALSE)
-    res4 <- read_modbam_cpp(bam4, "chr1", 0, "a", FALSE)
-    res5 <- read_modbam_cpp(bam5, "chr1", 0, "a", FALSE)
-    res6a <- read_modbam_cpp(modbamfile, "chr1:6941000-6941001", 0, "a", FALSE)
-    res6b <- read_modbam_cpp(modbamfile, c("chr1:6941000-6941001", "chr1:6928000-6928001"), 0, "a", FALSE)
+    res2 <- read_modbam_cpp(modbamfile, "chr1:", "a", 0, "", FALSE)
+    res3 <- read_modbam_cpp(modbamfile, c("chr1", "chr2"), "m", 0, "", FALSE)
+    res4 <- read_modbam_cpp(bam4, "chr1", "a", 0, "", FALSE)
+    res5 <- read_modbam_cpp(bam5, "chr1", "a", 0, "", FALSE)
+    res6a <- read_modbam_cpp(modbamfile, "chr1:6941000-6941001", "a", 0, "", FALSE)
+    res6b <- read_modbam_cpp(modbamfile, c("chr1:6941000-6941001", "chr1:6928000-6928001"), "a", 0, "", FALSE)
     aln6a <- Rsamtools::scanBam(file = modbamfile,
                                 param = Rsamtools::ScanBamParam(
                                     what = "qname",
@@ -130,6 +149,20 @@ test_that("read_modbam_cpp works", {
                                     what = "qname",
                                     which = GRanges(c("chr1:6941000-6941001", "chr1:6928000-6928001"))
                                 ))
+    set.seed(1L)
+    res7a <- read_modbam_cpp(modbamfile, "chr1", "a", 3, "chr1", FALSE)
+    set.seed(1L)
+    res7b <- read_modbam_cpp(modbamfile, "chr1", "a", 3, "chr1", FALSE)
+    expect_message(
+        expect_message(
+            expect_message(
+                expect_message(
+                    res7c <- read_modbam_cpp(modbamfile, "chr1", "a", 3, "chr1", TRUE),
+                    "opening input file"
+                ), "sampling"
+            ), "reading alignments overlapping"
+        ), "removed"
+    )
 
     # ... results structure
     expect_type(res1, "list")
@@ -139,6 +172,9 @@ test_that("read_modbam_cpp works", {
     expect_type(res5, "list")
     expect_type(res6a, "list")
     expect_type(res6b, "list")
+    expect_type(res7a, "list")
+    expect_type(res7b, "list")
+    expect_type(res7c, "list")
 
     expected_names <- c("read_id", "qscore", "forward_read_position",
                         "ref_position", "chrom", "ref_mod_strand", "call_code",
@@ -150,6 +186,9 @@ test_that("read_modbam_cpp works", {
     expect_named(res5, expected_names)
     expect_named(res6a, expected_names)
     expect_named(res6b, expected_names)
+    expect_named(res7a, expected_names)
+    expect_named(res7b, expected_names)
+    expect_named(res7c, expected_names)
 
     expected_types <- c("character", "double", "integer", "integer",
                         "character", "character", "character", "character",
@@ -162,6 +201,9 @@ test_that("read_modbam_cpp works", {
         expect_type(res5[[expected_names[i]]], expected_types[i])
         expect_type(res6a[[expected_names[i]]], expected_types[i])
         expect_type(res6b[[expected_names[i]]], expected_types[i])
+        expect_type(res7a[[expected_names[i]]], expected_types[i])
+        expect_type(res7b[[expected_names[i]]], expected_types[i])
+        expect_type(res7c[[expected_names[i]]], expected_types[i])
     }
 
     # ... content res1
@@ -264,4 +306,10 @@ test_that("read_modbam_cpp works", {
                  paste(res6b$chrom, res6b$ref_position, res6b$ref_mod_strand, res6b$read_id))
     expect_true(all(!is.na(idx)))
     expect_identical(res6a$mod_prob, res6b$mod_prob[idx])
+
+    # ... content of res7a, res7b and res7c
+    expect_identical(res7a, res7b)
+    expect_length(unique(res7a$read_id), 3L)
+    expect_false(identical(res7a, res7c))
+    expect_length(unique(res7c$read_id), 2L)
 })

--- a/tests/testthat/test-subsetReads.R
+++ b/tests/testthat/test-subsetReads.R
@@ -13,7 +13,8 @@ test_that("subsetReads works", {
     modbamfiles <- system.file("extdata",
                             c("6mA_1_10reads.bam", "6mA_2_10reads.bam"),
                             package = "footprintR")
-    se <- readModBam(modbamfiles, "chr1:6940000-6955000", "a")
+    se <- readModBam(bamfiles = modbamfiles,
+                     regions = "chr1:6940000-6955000", modbase = "a")
     se2 <- addReadsSummary(se, keep.reads = FALSE)
     se3 <- se
     assays(se3) <- SimpleList(mod_prob = assay(se, "mod_prob"),

--- a/tests/testthat/test_modbase_spacing.R
+++ b/tests/testthat/test_modbase_spacing.R
@@ -10,7 +10,7 @@ test_that("calcModbaseSpacing(), estimateNRL() and calcAndCountDist() work prope
     ## create modified-base distances using 6mA data (20 reads) from chr1:6940000-6955000
     bamf <- system.file("extdata", c("6mA_1_10reads.bam", "6mA_2_10reads.bam"),
                         package = "footprintR")
-    se <- readModBam(bamf, "chr1:6940000-6955000", "a")
+    se <- readModBam(bamfiles = bamf, regions = "chr1:6940000-6955000", modbase = "a")
     expect_error(calcModbaseSpacing("error"),
                  "must be of class 'RangedSummarizedExperiment'")
     expect_error(calcModbaseSpacing(se, "error"),


### PR DESCRIPTION
This should address #11 

Implemented sampling algorith
- user provides number of alignments to sample and chromosome names from which to sample (`nAlnsToSample` and `seqnamesToSampleFrom` arguments)
- `read_modbam_cpp` checks index for number of alignments on these chromosomes and calculates the fraction of alignments to keep
- it then sequentially reads the alignments from these chromosomes and accepts/rejects them based on that probability