### PR TITLE
Add 'quickread' option to readModBam to get read-level data from pileup

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -127,16 +127,6 @@ NULL
 #' @keywords internal
 NULL
 
-#' Find unique values in a vector
-#' 
-#' @param original A string vector with possibly repeated values
-#' 
-#' @return A vector with only the unique values from 'original'
-#' 
-#' @noRd
-#' @keywords internal
-NULL
-
 #' Read and pile-up base modifications from a bam file.
 #'
 #' Parse ML and MM tags (see https://samtools.github.io/hts-specs/SAMtags.pdf,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -127,6 +127,16 @@ NULL
 #' @keywords internal
 NULL
 
+#' Find unique values in a vector
+#' 
+#' @param original A string vector with possibly repeated values
+#' 
+#' @return A vector with only the unique values from 'original'
+#' 
+#' @noRd
+#' @keywords internal
+NULL
+
 #' Read and pile-up base modifications from a bam file.
 #'
 #' Parse ML and MM tags (see https://samtools.github.io/hts-specs/SAMtags.pdf,
@@ -147,6 +157,11 @@ NULL
 #' @param modbase Character scalar defining the modified base to extract.
 #'     Only modifications corresponding to \code{modbase} and with the
 #'     corresponding expected base in the read sequence will be extracted.
+#' @param level Character scalar indicating whether to return summary-level or
+#'     read-level data. Valid values are "summary" and "read". The read-level
+#'     results from \code{pileup_modbam_cpp} correspond to those from 
+#'     \code{read_modbam_cpp}, but does not contain all annotations currently
+#'     returned by the latter. 
 #' @param mod_prob_thresh Double scalar defining the minimal mod_prob
 #'     of a base to be considered modified.
 #' @param n_threads Integer scalar defining the number of threads to
@@ -158,12 +173,17 @@ NULL
 #' @return A named list with elements \code{"chrom"} (chromosome name),
 #'     \code{"ref_position"} (1-based coordinate on \code{"chrom"}),
 #'     \code{"ref_mod_strand"} (the strand relative to the reference on which
-#'     the modification was identified),  \code{"Nmod"} (number of modified
-#'     bases) and \code{"Nvalid"} (number of total bases).
+#'     the modification was identified). If \code{level} is \code{"summary"}, 
+#'     the list additionally contains slots \code{"Nmod"} (number of modified
+#'     bases) and \code{"Nvalid"} (number of total bases). If \code{level} is
+#'     \code{"read"}, it contains slots \code{"mod_prob"} and \code{"read_id"}.
 #'
 #' @examples
 #' modbamfile <- system.file("extdata", "6mA_1_10reads.bam", package = "footprintR")
-#' res <- pileup_modbam_cpp(modbamfile, "chr1", "a", 0.7, 1, TRUE)
+#' res <- pileup_modbam_cpp(modbamfile, "chr1", "a", "summary", 0.7, 1, TRUE)
+#' str(res)
+#' 
+#' res <- pileup_modbam_cpp(modbamfile, "chr1", "a", "read", 0.7, 1, TRUE)
 #' str(res)
 #'
 #' @seealso https://samtools.github.io/hts-specs/SAMtags.pdf describing the
@@ -171,14 +191,14 @@ NULL
 #'     Helpful examples are available in
 #'      https://github.com/samtools/htslib/blob/develop/samples/pileup_mod.c
 #'
-#' @author Michael Stadler
+#' @author Michael Stadler, Charlotte Soneson
 #'
 #' @importFrom cli cli_progress_step cli_progress_done
 #'
 #' @noRd
 #' @keywords internal
-pileup_modbam_cpp <- function(inname_str, regions, modbase, mod_prob_thresh = 0.5, n_threads = 2L, verbose = FALSE) {
-    .Call(`_footprintR_pileup_modbam_cpp`, inname_str, regions, modbase, mod_prob_thresh, n_threads, verbose)
+pileup_modbam_cpp <- function(inname_str, regions, modbase, level = "summary", mod_prob_thresh = 0.5, n_threads = 2L, verbose = FALSE) {
+    .Call(`_footprintR_pileup_modbam_cpp`, inname_str, regions, modbase, level, mod_prob_thresh, n_threads, verbose)
 }
 
 #' Read base modifications from a bam file.

--- a/R/readModBam.R
+++ b/R/readModBam.R
@@ -289,6 +289,7 @@ readModBam <- function(bamfiles,
                                           n_threads = as.integer(myncpuDecompression),
                                           verbose = myverbose)
                 resL$mod_prob[resL$mod_prob == -1] <- 0
+                resL$read_df <- resL$read_df[resL$read_df$read_id %in% resL$read_id, ]
             }
             resL
     }, BPPARAM = BPPARAM)
@@ -414,5 +415,9 @@ readModBam <- function(bamfiles,
         colnames(se) <- rownames(colData(se))
     }
 
+    # Remove reads with all NA values
+    if (level %in% c("read", "quickread")) {
+        se <- filterReads(se, readInfoCol = NULL, qcCol = NULL, prune = FALSE)
+    }
     se
 }

--- a/R/readModBam.R
+++ b/R/readModBam.R
@@ -30,6 +30,9 @@
 #'     \describe{
 #'         \item{"read"}{: Extracts modification probabilities for individual
 #'             reads into an assay called \code{"mod_prob"}.}
+#'         \item{"quickread"}{: Like "read", but runs faster, does not support
+#'             read sampling, and does not return all annotations currently 
+#'             provided by "read".}
 #'         \item{"summary"}{: Counts the total and modified bases for each
 #'             position and strand and returns them in assays named 
 #'             \code{"Nvalid"} and \code{"Nmod"}, respectively.}
@@ -135,7 +138,7 @@ readModBam <- function(bamfiles,
         stop("`names(bamfiles)` are not unique")
     }
     .assertScalar(x = level, type = "character", 
-                  validValues = c("read", "summary"))
+                  validValues = c("read", "summary", "quickread"))
     .assertVector(x = sampleAnnot, type = "data.frame", allowNULL = TRUE)
     if (!is.null(sampleAnnot)) {
         if (!("sample" %in% colnames(sampleAnnot))) {
@@ -170,8 +173,8 @@ readModBam <- function(bamfiles,
              paste(unique(modbase[i]), collapse = ", "))
     }
     .assertScalar(x = nAlnsToSample, type = "numeric", rngIncl = c(0, Inf))
-    if (nAlnsToSample > 0 && level == "summary") {
-        stop("Read sampling is not supported if level is set to 'summary'")
+    if (nAlnsToSample > 0 && level %in% c("summary", "quickread")) {
+        stop("Read sampling is not supported if level is set to 'summary' or 'quickread'")
     }
     if (nAlnsToSample > 0) {
         if (length(regions) > 0) {
@@ -269,13 +272,23 @@ readModBam <- function(bamfiles,
                 # modification probabilities less than 0.05, and read_modbam_cpp returns
                 # a mod_prob of -1 for these.
                 resL$mod_prob[resL$mod_prob == -1] <- 0
-            } else {
+            } else if (mylevel == "summary") {
                 resL <- pileup_modbam_cpp(inname_str = bamf,
                                           regions = myregions_str,
                                           modbase = mymodbase,
+                                          level = "summary",
                                           mod_prob_thresh = mymodProbThreshold,
                                           n_threads = as.integer(myncpuDecompression),
                                           verbose = myverbose)
+            } else if (mylevel == "quickread") {
+                resL <- pileup_modbam_cpp(inname_str = bamf,
+                                          regions = myregions_str,
+                                          modbase = mymodbase,
+                                          level = "read",
+                                          mod_prob_thresh = mymodProbThreshold,
+                                          n_threads = as.integer(myncpuDecompression),
+                                          verbose = myverbose)
+                resL$mod_prob[resL$mod_prob == -1] <- 0
             }
             resL
     }, BPPARAM = BPPARAM)
@@ -305,7 +318,7 @@ readModBam <- function(bamfiles,
             sequenceReference = sequenceReference)
     }
 
-    if (level == "read") {
+    if (level %in% c("read", "quickread")) {
         # extract unique read names
         readL <- lapply(resLL, function(resL) resL$read_df$read_id)
         
@@ -326,15 +339,23 @@ readModBam <- function(bamfiles,
                 modmat[[nm]] <- namat
                 rownames(x$read_df) <- paste0(nm, "-", x$read_df$read_id)
                 x$read_df$read_id <- NULL
-                x$read_df$aligned_fraction <- x$read_df$aligned_length / x$read_df$read_length
+                if (level == "read") {
+                    x$read_df$aligned_fraction <- x$read_df$aligned_length / x$read_df$read_length
+                } else {
+                    x$read_df$aligned_fraction <- NA_real_
+                }
                 readdfL[[nm]] <- DataFrame(x$read_df)
             } else {
                 modmat[[nm]] <- NaArray(dim = c(length(gpos), 0), type = "double")
-                readdfL[[nm]] <- DataFrame(qscore = numeric(0),
-                                           read_length = integer(0),
-                                           aligned_length = integer(0),
-                                           variant_label = character(0),
-                                           aligned_fraction = numeric(0))
+                if (level == "read") {
+                    readdfL[[nm]] <- DataFrame(qscore = numeric(0),
+                                               read_length = integer(0),
+                                               aligned_length = integer(0),
+                                               variant_label = character(0),
+                                               aligned_fraction = numeric(0))   
+                } else {
+                    readdfL[[nm]] <- DataFrame(aligned_fraction = numeric(0))
+                }
             }
         }
     } else {
@@ -357,7 +378,7 @@ readModBam <- function(bamfiles,
         sample = names(bamfiles),
         modbase = modbase[names(bamfiles)]
     )
-    if (level == "read") {
+    if (level %in% c("read", "quickread")) {
         cdata <- cbind(
             cdata, 
             DataFrame(n_reads = unlist(lapply(readdfL, nrow), use.names = FALSE),
@@ -370,7 +391,7 @@ readModBam <- function(bamfiles,
                                    drop = FALSE]
         cdata <- cbind(cdata, sampleAnnot)
     }
-    if (level == "read") {
+    if (level %in% c("read", "quickread")) {
         stopifnot(names(modmat) == cdata$sample)
         se <- SummarizedExperiment(
             assays = list(mod_prob = modmat),

--- a/R/readModBam.R
+++ b/R/readModBam.R
@@ -339,23 +339,15 @@ readModBam <- function(bamfiles,
                 modmat[[nm]] <- namat
                 rownames(x$read_df) <- paste0(nm, "-", x$read_df$read_id)
                 x$read_df$read_id <- NULL
-                if (level == "read") {
-                    x$read_df$aligned_fraction <- x$read_df$aligned_length / x$read_df$read_length
-                } else {
-                    x$read_df$aligned_fraction <- NA_real_
-                }
+                x$read_df$aligned_fraction <- x$read_df$aligned_length / x$read_df$read_length
                 readdfL[[nm]] <- DataFrame(x$read_df)
             } else {
                 modmat[[nm]] <- NaArray(dim = c(length(gpos), 0), type = "double")
-                if (level == "read") {
-                    readdfL[[nm]] <- DataFrame(qscore = numeric(0),
-                                               read_length = integer(0),
-                                               aligned_length = integer(0),
-                                               variant_label = character(0),
-                                               aligned_fraction = numeric(0))   
-                } else {
-                    readdfL[[nm]] <- DataFrame(aligned_fraction = numeric(0))
-                }
+                readdfL[[nm]] <- DataFrame(qscore = numeric(0),
+                                           read_length = integer(0),
+                                           aligned_length = integer(0),
+                                           variant_label = character(0),
+                                           aligned_fraction = numeric(0))   
             }
         }
     } else {

--- a/man/readModBam.Rd
+++ b/man/readModBam.Rd
@@ -51,6 +51,9 @@ data. Supported values are:
 \describe{
 \item{"read"}{: Extracts modification probabilities for individual
 reads into an assay called \code{"mod_prob"}.}
+\item{"quickread"}{: Like "read", but runs faster, does not support
+read sampling, and does not return all annotations currently
+provided by "read".}
 \item{"summary"}{: Counts the total and modified bases for each
 position and strand and returns them in assays named
 \code{"Nvalid"} and \code{"Nmod"}, respectively.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -51,18 +51,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // pileup_modbam_cpp
-Rcpp::List pileup_modbam_cpp(std::string inname_str, std::vector<std::string> regions, char modbase, double mod_prob_thresh, int n_threads, bool verbose);
-RcppExport SEXP _footprintR_pileup_modbam_cpp(SEXP inname_strSEXP, SEXP regionsSEXP, SEXP modbaseSEXP, SEXP mod_prob_threshSEXP, SEXP n_threadsSEXP, SEXP verboseSEXP) {
+Rcpp::List pileup_modbam_cpp(std::string inname_str, std::vector<std::string> regions, char modbase, std::string level, double mod_prob_thresh, int n_threads, bool verbose);
+RcppExport SEXP _footprintR_pileup_modbam_cpp(SEXP inname_strSEXP, SEXP regionsSEXP, SEXP modbaseSEXP, SEXP levelSEXP, SEXP mod_prob_threshSEXP, SEXP n_threadsSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type inname_str(inname_strSEXP);
     Rcpp::traits::input_parameter< std::vector<std::string> >::type regions(regionsSEXP);
     Rcpp::traits::input_parameter< char >::type modbase(modbaseSEXP);
+    Rcpp::traits::input_parameter< std::string >::type level(levelSEXP);
     Rcpp::traits::input_parameter< double >::type mod_prob_thresh(mod_prob_threshSEXP);
     Rcpp::traits::input_parameter< int >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
-    rcpp_result_gen = Rcpp::wrap(pileup_modbam_cpp(inname_str, regions, modbase, mod_prob_thresh, n_threads, verbose));
+    rcpp_result_gen = Rcpp::wrap(pileup_modbam_cpp(inname_str, regions, modbase, level, mod_prob_thresh, n_threads, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -125,7 +126,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_footprintR_calcAndCountDist", (DL_FUNC) &_footprintR_calcAndCountDist, 3},
     {"_footprintR_calcFootprintScoreForRead", (DL_FUNC) &_footprintR_calcFootprintScoreForRead, 5},
     {"_footprintR_labelDists", (DL_FUNC) &_footprintR_labelDists, 2},
-    {"_footprintR_pileup_modbam_cpp", (DL_FUNC) &_footprintR_pileup_modbam_cpp, 6},
+    {"_footprintR_pileup_modbam_cpp", (DL_FUNC) &_footprintR_pileup_modbam_cpp, 7},
     {"_footprintR_read_modbam_cpp", (DL_FUNC) &_footprintR_read_modbam_cpp, 9},
     {"_footprintR_sampleEntropy", (DL_FUNC) &_footprintR_sampleEntropy, 3},
     {"_footprintR_get_unmodified_base", (DL_FUNC) &_footprintR_get_unmodified_base, 1},

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -363,7 +363,13 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                     df_variant_label.push_back(NA_STRING);
                 }
 
-                if (modlen > 0) {
+                if (modlen > (int)(sizeof(mods) / sizeof(mods[0]))) {
+                    had_error = true;
+                    snprintf(buffer, buffer_len,
+                             "More modifications than footprintR:::pileup_modbam_cpp can handle (read %s)\n",
+                             bam_get_qname(plp[j].b));
+                    goto end;
+                } else if (modlen > 0) {
                     curr_strand = bam_is_rev(plp[j].b) == mods[0].strand ? 0 : 1;
                     if (level == "summary") {
                         curr_Nvalid[curr_strand]++;
@@ -377,7 +383,7 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                         read_id.push_back(bam_get_qname(plp[j].b));
                         mod_prob.push_back(((double) mods[0].qual + 0.5) / 256.0);
                     }
-                } else if (impl) {
+                } else if (!modlen && impl) {
                     curr_strand = bam_is_rev(plp[j].b) ? 1 : 0;
                     if (level == "summary") {
                         curr_Nvalid[curr_strand]++;

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -309,6 +309,30 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
         
         // iterate over reads overlapping refpos
         for (j = 0; j < depth; ++j) {
+            // if this is the first time the read is seen, add it to the 
+            // read df vectors
+            if (level == "read" && plp[j].is_head) {
+                // if (level == "read" && std::find(df_read_id.begin(), df_read_id.end(), bam_get_qname(plp[j].b)) == df_read_id.end()) {
+                qs_data = bam_aux_get(plp[j].b, "qs");
+                if (qs_data != NULL) {
+                    qs_value = bam_aux2f(qs_data);
+                } else {
+                    // qs tag is missing
+                    //   --> calculate mean of base QUAL values
+                    qual = bam_get_qual(plp[j].b);
+                    sum_qual = 0;
+                    for (v = 0; v < plp[j].b->core.l_qseq; v++) {
+                        sum_qual += qual[v];
+                    }
+                    qs_value = ((double) sum_qual) / plp[j].b->core.l_qseq;
+                }
+                df_read_id.push_back(bam_get_qname(plp[j].b));
+                df_qscore.push_back(qs_value);
+                df_read_length.push_back(plp[j].b->core.l_qseq);
+                df_aligned_length.push_back(calculate_aligned_bases(plp[j].b));
+                df_variant_label.push_back(NA_STRING);
+            }
+            
             if (plp[j].is_del || plp[j].is_refskip ||
                 (plp[j].b->core.flag & BAM_FSECONDARY) ||
                 (plp[j].b->core.flag & BAM_FSUPPLEMENTARY)) {
@@ -339,29 +363,6 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
             // increment curr_Nmod[curr_strand] if base is modified and has the expected base
             if (bam_mods_query_type((hts_base_mod_state*)plp[j].cd.p, 
                                     modbase, &strand, &impl, &canonical) == 0) {
-                
-                // if this is the first time the read is seen, add it to the 
-                // read df vectors
-                if (level == "read" && std::find(df_read_id.begin(), df_read_id.end(), bam_get_qname(plp[j].b)) == df_read_id.end()) {
-                    qs_data = bam_aux_get(plp[j].b, "qs");
-                    if (qs_data != NULL) {
-                        qs_value = bam_aux2f(qs_data);
-                    } else {
-                        // qs tag is missing
-                        //   --> calculate mean of base QUAL values
-                        qual = bam_get_qual(plp[j].b);
-                        sum_qual = 0;
-                        for (v = 0; v < plp[j].b->core.l_qseq; v++) {
-                            sum_qual += qual[v];
-                        }
-                        qs_value = ((double) sum_qual) / plp[j].b->core.l_qseq;
-                    }
-                    df_read_id.push_back(bam_get_qname(plp[j].b));
-                    df_qscore.push_back(qs_value);
-                    df_read_length.push_back(plp[j].b->core.l_qseq);
-                    df_aligned_length.push_back(calculate_aligned_bases(plp[j].b));
-                    df_variant_label.push_back(NA_STRING);
-                }
 
                 if (modlen > (int)(sizeof(mods) / sizeof(mods[0]))) {
                     had_error = true;

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -342,7 +342,7 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                 
                 // if this is the first time the read is seen, add it to the 
                 // read df vectors
-                if (std::find(df_read_id.begin(), df_read_id.end(), bam_get_qname(plp[j].b)) == df_read_id.end()) {
+                if (level == "read" && std::find(df_read_id.begin(), df_read_id.end(), bam_get_qname(plp[j].b)) == df_read_id.end()) {
                     qs_data = bam_aux_get(plp[j].b, "qs");
                     if (qs_data != NULL) {
                         qs_value = bam_aux2f(qs_data);

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -98,8 +98,7 @@ int plpdestructor(void *data, const bam1_t *b, bam_pileup_cd *cd) {
 //'
 //' @noRd
 //' @keywords internal
-int readdata(void *data, bam1_t *b)
-{
+int readdata(void *data, bam1_t *b) {
     plpconf *conf = (plpconf*)data;
     if (!conf || !conf->infile) {
         // # nocov start
@@ -110,6 +109,26 @@ int readdata(void *data, bam1_t *b)
     //read alignment and send
     // return sam_read1(conf->infile, conf->infile->bam_header, b);
     return sam_itr_next(conf->infile, conf->iter, b);
+}
+
+//' Find unique values in a vector
+//' 
+//' @param original A string vector with possibly repeated values
+//' 
+//' @return A vector with only the unique values from 'original'
+//' 
+//' @noRd
+//' @keywords internal
+std::vector<std::string> uniquevals(const std::vector<std::string> &original) {
+    std::vector<std::string> result;
+    std::set<std::string> aux;
+    for (auto it = original.begin(); it != original.end(); ++it) {
+        if (aux.find(*it) == aux.end()) {
+            aux.insert(*it);
+            result.push_back(*it);
+        }
+    }
+    return result;
 }
 
 //' Read and pile-up base modifications from a bam file.
@@ -132,6 +151,11 @@ int readdata(void *data, bam1_t *b)
 //' @param modbase Character scalar defining the modified base to extract.
 //'     Only modifications corresponding to \code{modbase} and with the
 //'     corresponding expected base in the read sequence will be extracted.
+//' @param level Character scalar indicating whether to return summary-level or
+//'     read-level data. Valid values are "summary" and "read". The read-level
+//'     results from \code{pileup_modbam_cpp} correspond to those from 
+//'     \code{read_modbam_cpp}, but does not contain all annotations currently
+//'     returned by the latter. 
 //' @param mod_prob_thresh Double scalar defining the minimal mod_prob
 //'     of a base to be considered modified.
 //' @param n_threads Integer scalar defining the number of threads to
@@ -143,12 +167,17 @@ int readdata(void *data, bam1_t *b)
 //' @return A named list with elements \code{"chrom"} (chromosome name),
 //'     \code{"ref_position"} (1-based coordinate on \code{"chrom"}),
 //'     \code{"ref_mod_strand"} (the strand relative to the reference on which
-//'     the modification was identified),  \code{"Nmod"} (number of modified
-//'     bases) and \code{"Nvalid"} (number of total bases).
+//'     the modification was identified). If \code{level} is \code{"summary"}, 
+//'     the list additionally contains slots \code{"Nmod"} (number of modified
+//'     bases) and \code{"Nvalid"} (number of total bases). If \code{level} is
+//'     \code{"read"}, it contains slots \code{"mod_prob"} and \code{"read_id"}.
 //'
 //' @examples
 //' modbamfile <- system.file("extdata", "6mA_1_10reads.bam", package = "footprintR")
-//' res <- pileup_modbam_cpp(modbamfile, "chr1", "a", 0.7, 1, TRUE)
+//' res <- pileup_modbam_cpp(modbamfile, "chr1", "a", "summary", 0.7, 1, TRUE)
+//' str(res)
+//' 
+//' res <- pileup_modbam_cpp(modbamfile, "chr1", "a", "read", 0.7, 1, TRUE)
 //' str(res)
 //'
 //' @seealso https://samtools.github.io/hts-specs/SAMtags.pdf describing the
@@ -156,7 +185,7 @@ int readdata(void *data, bam1_t *b)
 //'     Helpful examples are available in
 //'      https://github.com/samtools/htslib/blob/develop/samples/pileup_mod.c
 //'
-//' @author Michael Stadler
+//' @author Michael Stadler, Charlotte Soneson
 //'
 //' @importFrom cli cli_progress_step cli_progress_done
 //'
@@ -166,6 +195,7 @@ int readdata(void *data, bam1_t *b)
 Rcpp::List pileup_modbam_cpp(std::string inname_str,
                              std::vector<std::string> regions,
                              char modbase,
+                             std::string level = "summary",
                              double mod_prob_thresh = 0.5,
                              int n_threads = 2,
                              bool verbose = false) {
@@ -189,15 +219,19 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
     char **regions_c = NULL;
     int strand = 0, impl = 0;
     char canonical = '0';
+    Rcpp::List res;
 
-    std::vector<std::string> chrom;
-    std::vector<int> ref_position;
-    std::vector<char> ref_mod_strand;
+    // ... return values
     std::vector<int> Nmod;
     std::vector<int> Nvalid;
+    std::vector<double> mod_prob;
+    std::vector<std::string> read_id;
     int curr_Nmod[2] = {0, 0};   // for +/- strand modification counts
     int curr_Nvalid[2] = {0, 0};
     int curr_strand = 0;
+    std::vector<std::string> chrom;
+    std::vector<int> ref_position;
+    std::vector<char> ref_mod_strand;
 
     // ... cli progress bar
     Rcpp::RObject bar;
@@ -315,36 +349,54 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                                     modbase, &strand, &impl, &canonical) == 0) {
                 if (modlen > 0) {
                     curr_strand = bam_is_rev(plp[j].b) == mods[0].strand ? 0 : 1;
-                    curr_Nvalid[curr_strand]++;
-                    if ((((double) mods[0].qual + 0.5) / 256.0) >= mod_prob_thresh) {
-                        curr_Nmod[curr_strand]++;
+                    if (level == "summary") {
+                        curr_Nvalid[curr_strand]++;
+                        if ((((double) mods[0].qual + 0.5) / 256.0) >= mod_prob_thresh) {
+                            curr_Nmod[curr_strand]++;
+                        }
+                    } else if (level == "read") {
+                        chrom.push_back(sam_hdr_tid2name(conf.in_samhdr, tid));
+                        ref_position.push_back(refpos + 1);
+                        ref_mod_strand.push_back(curr_strand == 0 ? '+' : '-');
+                        read_id.push_back(bam_get_qname(plp[j].b));
+                        mod_prob.push_back(((double) mods[0].qual + 0.5) / 256.0);
                     }
                 } else {
                     curr_strand = bam_is_rev(plp[j].b) ? 1 : 0;
-                    curr_Nvalid[curr_strand]++;
+                    if (level == "summary") {
+                        curr_Nvalid[curr_strand]++;
+                    } else if (level == "read") {
+                        chrom.push_back(sam_hdr_tid2name(conf.in_samhdr, tid));
+                        ref_position.push_back(refpos + 1);
+                        ref_mod_strand.push_back(curr_strand == 0 ? '+' : '-');
+                        read_id.push_back(bam_get_qname(plp[j].b));
+                        mod_prob.push_back(-1.0);
+                    }
                 }
             }
         }
 
         // add counters for refpos to return value vectors
-        // ... plus strand
-        if (curr_Nvalid[0] > 0) {
-            chrom.push_back(sam_hdr_tid2name(conf.in_samhdr, tid));
-            ref_position.push_back(refpos + 1);
-            ref_mod_strand.push_back('+');
-            Nmod.push_back(curr_Nmod[0]);
-            Nvalid.push_back(curr_Nvalid[0]);
+        if (level == "summary") {
+            // ... plus strand
+            if (curr_Nvalid[0] > 0) {
+                chrom.push_back(sam_hdr_tid2name(conf.in_samhdr, tid));
+                ref_position.push_back(refpos + 1);
+                ref_mod_strand.push_back('+');
+                Nmod.push_back(curr_Nmod[0]);
+                Nvalid.push_back(curr_Nvalid[0]);
+            }
+            
+            // ... minus strand
+            if (curr_Nvalid[1] > 0) {
+                chrom.push_back(sam_hdr_tid2name(conf.in_samhdr, tid));
+                ref_position.push_back(refpos + 1);
+                ref_mod_strand.push_back('-');
+                Nmod.push_back(curr_Nmod[1]);
+                Nvalid.push_back(curr_Nvalid[1]);
+            }
         }
-
-        // ... minus strand
-        if (curr_Nvalid[1] > 0) {
-            chrom.push_back(sam_hdr_tid2name(conf.in_samhdr, tid));
-            ref_position.push_back(refpos + 1);
-            ref_mod_strand.push_back('-');
-            Nmod.push_back(curr_Nmod[1]);
-            Nvalid.push_back(curr_Nvalid[1]);
-        }
-
+        
         refposcount++;
         if (verbose && CLI_SHOULD_TICK) {
             // # nocov start
@@ -386,13 +438,27 @@ end:
 
     } else {
         // create return list
-        Rcpp::List res = Rcpp::List::create(
-            Rcpp::_["chrom"] = chrom,
-            Rcpp::_["ref_position"] = ref_position,
-            Rcpp::_["ref_mod_strand"] = ref_mod_strand,
-            Rcpp::_["Nmod"] = Nmod,
-            Rcpp::_["Nvalid"] = Nvalid);
+        if (level == "summary") {
+            res = Rcpp::List::create(
+                Rcpp::_["chrom"] = chrom,
+                Rcpp::_["ref_position"] = ref_position,
+                Rcpp::_["ref_mod_strand"] = ref_mod_strand,
+                Rcpp::_["Nmod"] = Nmod,
+                Rcpp::_["Nvalid"] = Nvalid);
+        } else if (level == "read") {
+            std::vector<std::string> df_read_id = uniquevals(read_id);
+            Rcpp::DataFrame df = Rcpp::DataFrame::create(
+                Rcpp::_["read_id"] = df_read_id);
+            res = Rcpp::List::create(
+                Rcpp::_["chrom"] = chrom,
+                Rcpp::_["ref_position"] = ref_position,
+                Rcpp::_["ref_mod_strand"] = ref_mod_strand,
+                Rcpp::_["mod_prob"] = mod_prob,
+                Rcpp::_["read_id"] = read_id,
+                Rcpp::_["read_df"] = df);
+        }
 
         return res;
     }
 }
+

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -179,12 +179,15 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                              double mod_prob_thresh = 0.5,
                              int n_threads = 2,
                              bool verbose = false) {
+    // turn htslib logging off -> handle via Rcpp::warning or Rcpp::stop
+    hts_set_log_level(HTS_LOG_OFF);
+    
     // variable declarations
     bam1_t *bamdata = NULL;
     plpconf conf = {0};
     conf.inname = (char*)inname_str.c_str();
     bam_plp_t plpiter = NULL;
-    int tid = -1, depth = -1, j = 0, modlen = 0;
+    int tid = -1, depth = -1, j = 0, modlen = 0, v = 0;
     #define NMODS 5
     hts_base_mod mods[NMODS] = {{0}}; //ACGTN
     int refpos = -1;
@@ -348,8 +351,8 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                         //   --> calculate mean of base QUAL values
                         qual = bam_get_qual(plp[j].b);
                         sum_qual = 0;
-                        for (j = 0; j < plp[j].b->core.l_qseq; j++) {
-                            sum_qual += qual[j];
+                        for (v = 0; v < plp[j].b->core.l_qseq; v++) {
+                            sum_qual += qual[v];
                         }
                         qs_value = ((double) sum_qual) / plp[j].b->core.l_qseq;
                     }

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -111,26 +111,6 @@ int readdata(void *data, bam1_t *b) {
     return sam_itr_next(conf->infile, conf->iter, b);
 }
 
-//' Find unique values in a vector
-//' 
-//' @param original A string vector with possibly repeated values
-//' 
-//' @return A vector with only the unique values from 'original'
-//' 
-//' @noRd
-//' @keywords internal
-std::vector<std::string> uniquevals(const std::vector<std::string> &original) {
-    std::vector<std::string> result;
-    std::set<std::string> aux;
-    for (auto it = original.begin(); it != original.end(); ++it) {
-        if (aux.find(*it) == aux.end()) {
-            aux.insert(*it);
-            result.push_back(*it);
-        }
-    }
-    return result;
-}
-
 //' Read and pile-up base modifications from a bam file.
 //'
 //' Parse ML and MM tags (see https://samtools.github.io/hts-specs/SAMtags.pdf,
@@ -220,8 +200,11 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
     int strand = 0, impl = 0;
     char canonical = '0';
     Rcpp::List res;
+    uint8_t *qs_data = NULL, *qual = NULL;
+    unsigned int sum_qual = 0;
+    double qs_value = -1;
 
-    // ... return values
+    // ... return values (one per modification)
     std::vector<int> Nmod;
     std::vector<int> Nvalid;
     std::vector<double> mod_prob;
@@ -232,6 +215,13 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
     std::vector<std::string> chrom;
     std::vector<int> ref_position;
     std::vector<char> ref_mod_strand;
+    
+    // ... return values (one per aligned read)
+    std::vector<std::string> df_read_id;
+    std::vector<double> df_qscore;
+    std::vector<int> df_read_length;
+    std::vector<int> df_aligned_length;
+    Rcpp::CharacterVector df_variant_label;
 
     // ... cli progress bar
     Rcpp::RObject bar;
@@ -250,7 +240,7 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
     // open input files
     if (!(conf.infile = sam_open(conf.inname, "r"))) {
         had_error = true; // # nocov start
-        snprintf(buffer, buffer_len, "Could not open %s\n", conf.inname);
+        snprintf(buffer, buffer_len, "Could not open input file %s\n", conf.inname);
         goto end; // # nocov end
     }
 
@@ -346,6 +336,30 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
             // increment curr_Nmod[curr_strand] if base is modified and has the expected base
             if (bam_mods_query_type((hts_base_mod_state*)plp[j].cd.p, 
                                     modbase, &strand, &impl, &canonical) == 0) {
+                
+                // if this is the first time the read is seen, add it to the 
+                // read df vectors
+                if (std::find(df_read_id.begin(), df_read_id.end(), bam_get_qname(plp[j].b)) == df_read_id.end()) {
+                    qs_data = bam_aux_get(plp[j].b, "qs");
+                    if (qs_data != NULL) {
+                        qs_value = bam_aux2f(qs_data);
+                    } else {
+                        // qs tag is missing
+                        //   --> calculate mean of base QUAL values
+                        qual = bam_get_qual(plp[j].b);
+                        sum_qual = 0;
+                        for (j = 0; j < plp[j].b->core.l_qseq; j++) {
+                            sum_qual += qual[j];
+                        }
+                        qs_value = ((double) sum_qual) / plp[j].b->core.l_qseq;
+                    }
+                    df_read_id.push_back(bam_get_qname(plp[j].b));
+                    df_qscore.push_back(qs_value);
+                    df_read_length.push_back(plp[j].b->core.l_qseq);
+                    df_aligned_length.push_back(calculate_aligned_bases(plp[j].b));
+                    df_variant_label.push_back(NA_STRING);
+                }
+
                 if (modlen > 0) {
                     curr_strand = bam_is_rev(plp[j].b) == mods[0].strand ? 0 : 1;
                     if (level == "summary") {
@@ -445,9 +459,13 @@ end:
                 Rcpp::_["Nmod"] = Nmod,
                 Rcpp::_["Nvalid"] = Nvalid);
         } else if (level == "read") {
-            std::vector<std::string> df_read_id = uniquevals(read_id);
             Rcpp::DataFrame df = Rcpp::DataFrame::create(
-                Rcpp::_["read_id"] = df_read_id);
+                Rcpp::_["read_id"] = df_read_id,
+                Rcpp::_["qscore"] = df_qscore,
+                Rcpp::_["read_length"] = df_read_length,
+                Rcpp::_["aligned_length"] = df_aligned_length,
+                Rcpp::_["variant_label"] = df_variant_label
+            );
             res = Rcpp::List::create(
                 Rcpp::_["chrom"] = chrom,
                 Rcpp::_["ref_position"] = ref_position,

--- a/src/pileup_modbam_cpp.cpp
+++ b/src/pileup_modbam_cpp.cpp
@@ -313,10 +313,9 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
         curr_Nmod[1] = 0;
         curr_Nvalid[0] = 0;
         curr_Nvalid[1] = 0;
-
+        
         // iterate over reads overlapping refpos
         for (j = 0; j < depth; ++j) {
-
             if (plp[j].is_del || plp[j].is_refskip ||
                 (plp[j].b->core.flag & BAM_FSECONDARY) ||
                 (plp[j].b->core.flag & BAM_FSUPPLEMENTARY)) {
@@ -361,7 +360,7 @@ Rcpp::List pileup_modbam_cpp(std::string inname_str,
                         read_id.push_back(bam_get_qname(plp[j].b));
                         mod_prob.push_back(((double) mods[0].qual + 0.5) / 256.0);
                     }
-                } else {
+                } else if (impl) {
                     curr_strand = bam_is_rev(plp[j].b) ? 1 : 0;
                     if (level == "summary") {
                         curr_Nvalid[curr_strand]++;

--- a/src/read_modbam_cpp.cpp
+++ b/src/read_modbam_cpp.cpp
@@ -198,24 +198,6 @@ std::string construct_read_label(const bam1_t *aln,
     return label;
 }
 
-// calculate aligned bases (sum of 'M', '=', or 'X' operation lengths)
-int calculate_aligned_bases(bam1_t *bamdata) {
-    uint32_t *cigar = bam_get_cigar(bamdata);
-    int aligned_bases = 0;
-
-    // loop over CIGAR operations
-    for (uint32_t i = 0; i < bamdata->core.n_cigar; i++) {
-        uint32_t op = bam_cigar_op(cigar[i]);
-
-        // only count 'M', '=', or 'X' operations
-        if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
-            aligned_bases += bam_cigar_oplen(cigar[i]);
-        }
-    }
-
-    return aligned_bases;
-}
-
 // process a single bam record:
 // - increase alignment counter (passed by reference)
 // - extract information from record (qscore, modification information, etc.)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,3 +1,7 @@
+#include <htslib/sam.h>
+#include <string>
+#include <vector>
+
 //' Get unmodified base corresponding to a modified base
 //'
 //' @param b Modified base as a char
@@ -65,3 +69,20 @@ char complement(char n) {
     }
 }
 
+// calculate aligned bases (sum of 'M', '=', or 'X' operation lengths)
+int calculate_aligned_bases(bam1_t *bamdata) {
+    uint32_t *cigar = bam_get_cigar(bamdata);
+    int aligned_bases = 0;
+    
+    // loop over CIGAR operations
+    for (uint32_t i = 0; i < bamdata->core.n_cigar; i++) {
+        uint32_t op = bam_cigar_op(cigar[i]);
+        
+        // only count 'M', '=', or 'X' operations
+        if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
+            aligned_bases += bam_cigar_oplen(cigar[i]);
+        }
+    }
+    
+    return aligned_bases;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,2 +1,5 @@
+#include <htslib/sam.h>
+
 char get_unmodified_base(char);
 char complement(char);
+int calculate_aligned_bases(bam1_t*);

--- a/tests/testthat/test-pileup_modbam_cpp.R
+++ b/tests/testthat/test-pileup_modbam_cpp.R
@@ -1,4 +1,254 @@
 test_that("pileup_modbam_cpp works", {
+    ## example data ------------------------------------------------------------
+    modbamfile <- system.file("extdata", "6mA_1_10reads.bam",
+                              package = "footprintR")
+    extractfile <- system.file("extdata", "modkit_extract_rc_6mA_1.tsv.gz",
+                               package = "footprintR")
+    
+    bam4 <- system.file("extdata", "6mA_simple.bam", package = "footprintR")
+    bam5 <- system.file("extdata", "6mA_unaligned.bam", package = "footprintR")
+    bam7 <- system.file("extdata", "6mA_mod-issue.bam", package = "footprintR")
+    bam8 <- system.file("extdata", "6mA_too-many-mods.bam", package = "footprintR")
+    
+    ## invalid arguments -------------------------------------------------------
+    # ... non-existing bam file
+    expect_error(pileup_modbam_cpp(inname_str = "error", regions = "chr1",
+                                   modbase = "a", n_threads = 2, level = "read",
+                                   mod_prob_thresh = 0.5, verbose = FALSE),
+                 "Could not open input file")
+    
+    # ... no bam index
+    tmpbam <- tempfile(fileext = ".bam")
+    expect_true(file.copy(from = modbamfile, to = tmpbam))
+    expect_error(pileup_modbam_cpp(inname_str = tmpbam, regions = "chr1",
+                                   modbase = "a", n_threads = 2,
+                                   verbose = FALSE),
+                 "Failed to load the index")
+    unlink(tmpbam)
+
+    # ... requesting a region that is not contained in the bam header
+    expect_error(pileup_modbam_cpp(inname_str = bam4, regions = "chr2",
+                                   modbase = "a"),
+                 "Failed to get bam iterator")
+    
+    # ... too many modifications on a single base
+    # ... crashes
+    # expect_error(pileup_modbam_cpp(inname_str = bam8, regions = "chr1",
+    #                                modbase = "a", verbose = FALSE),
+    #              "More modifications than footprintR")
+    
+    ## expected results --------------------------------------------------------
+    # ... run pileup_modbam_cpp
+    df <- read.delim(extractfile)
+    df$ref_position <- df$ref_position + 1L # modkit-extract has 0-based coordinates
+    suppressMessages({
+        res1 <- pileup_modbam_cpp(inname_str = modbamfile,
+                                  regions = "chr1:6940000-6955000",
+                                  modbase = "a", level = "read",
+                                  n_threads = 2,
+                                  verbose = TRUE)
+    })
+    res2 <- pileup_modbam_cpp(inname_str = modbamfile, 
+                              regions = "chr1:", 
+                              modbase = "a", level = "read",
+                              n_threads = 1, 
+                              verbose = FALSE)
+    res3 <- pileup_modbam_cpp(inname_str = modbamfile, 
+                              regions = c("chr1", "chr2"), 
+                              modbase = "m", level = "read",
+                              n_threads = 1, 
+                              verbose = FALSE)
+    # ... crashes
+    # res4 <- pileup_modbam_cpp(inname_str = bam4,
+    #                           regions = "chr1",
+    #                           modbase = "a", level = "read",
+    #                           n_threads = 1,
+    #                           verbose = FALSE)
+    res5 <- pileup_modbam_cpp(inname_str = bam5, 
+                              regions = "chr1", 
+                              modbase = "a", level = "read",
+                              n_threads = 1, 
+                              verbose = FALSE)
+    res6a <- pileup_modbam_cpp(inname_str = modbamfile, 
+                               regions = "chr1:6941000-6941001", 
+                               modbase = "a", level = "read",
+                               n_threads = 1, 
+                               verbose = FALSE)
+    res6b <- pileup_modbam_cpp(inname_str = modbamfile, 
+                               regions = c("chr1:6941000-6941001", "chr1:6928000-6928001"), 
+                               modbase = "a", level = "read",
+                               n_threads = 1, 
+                               verbose = FALSE)
+    aln6a <- Rsamtools::scanBam(file = modbamfile,
+                                param = Rsamtools::ScanBamParam(
+                                    what = "qname",
+                                    which = GRanges("chr1:6941000-6941001")
+                                ))
+    aln6b <- Rsamtools::scanBam(file = modbamfile,
+                                param = Rsamtools::ScanBamParam(
+                                    what = "qname",
+                                    which = GRanges(c("chr1:6941000-6941001", "chr1:6928000-6928001"))
+                                ))
+    
+    # ... results structure
+    expect_type(res1, "list")
+    expect_type(res2, "list")
+    expect_type(res3, "list")
+    # expect_type(res4, "list")
+    expect_type(res5, "list")
+    expect_type(res6a, "list")
+    expect_type(res6b, "list")
+    
+    expected_names <- c(
+        "chrom", "ref_position", "ref_mod_strand", "mod_prob", "read_id", "read_df")
+    expect_named(res1, expected_names)
+    expect_named(res2, expected_names)
+    expect_named(res3, expected_names)
+    # expect_named(res4, expected_names)
+    expect_named(res5, expected_names)
+    expect_named(res6a, expected_names)
+    expect_named(res6b, expected_names)
+    
+    expected_types <- c(
+        "character", "integer", "character", "double",
+        "character", "list")
+    for (i in seq_along(expected_names)) {
+        expect_type(res1[[expected_names[i]]], expected_types[i])
+        expect_type(res2[[expected_names[i]]], expected_types[i])
+        expect_type(res3[[expected_names[i]]], expected_types[i])
+        # expect_type(res4[[expected_names[i]]], expected_types[i])
+        expect_type(res5[[expected_names[i]]], expected_types[i])
+        expect_type(res6a[[expected_names[i]]], expected_types[i])
+        expect_type(res6b[[expected_names[i]]], expected_types[i])
+    }
+    
+    expect_s3_class(res1[["read_df"]], "data.frame")
+    expect_s3_class(res2[["read_df"]], "data.frame")
+    expect_s3_class(res3[["read_df"]], "data.frame")
+    # expect_s3_class(res4[["read_df"]], "data.frame")
+    expect_s3_class(res5[["read_df"]], "data.frame")
+    expect_s3_class(res6a[["read_df"]], "data.frame")
+    expect_s3_class(res6b[["read_df"]], "data.frame")
+    
+    expected_df_colnames <- c("read_id", "qscore", "read_length", "aligned_length", "variant_label")
+    expect_named(res1$read_df, expected_df_colnames)
+    expect_named(res2$read_df, expected_df_colnames)
+    expect_named(res3$read_df, expected_df_colnames)
+    # expect_named(res4$read_df, expected_df_colnames)
+    expect_named(res5$read_df, expected_df_colnames)
+    expect_named(res6a$read_df, expected_df_colnames)
+    expect_named(res6b$read_df, expected_df_colnames)
+    
+    # ... content res1
+    expect_identical(res1$read_df$read_id,
+                     c("233e48a7-f379-4dcf-9270-958231125563",
+                       "d52a5f6a-a60a-4f85-913e-eada84bfbfb9",
+                       "92e906ae-cddb-4347-a114-bf9137761a8d"))
+    expect_equal(res1$read_df$qscore,
+                 c(14.1428003311157, 16.0126991271973, 20.3082008361816))
+    expect_identical(res1$read_df$read_length, c(20058L, 11305L, 12277L))
+    expect_identical(res1$read_df$aligned_length, c(14801L, 11214L, 12227L))
+    expect_identical(res1$read_df$variant_label, rep(NA_character_, 3L))
+    expect_identical(unname(sort(as.vector(table(res1$read_id)))),
+                     c(3340L,  3597L, 4363L))
+    expect_true(all(res1$mod_prob == -1 | (res1$mod_prob >= 0 & res1$mod_prob <= 1.0)))
+    for (nm in setdiff(expected_names, "read_df")) {
+        expect_length(res1[[nm]], 11300L)
+    }
+    expect_length(unique(res1$read_id), 3L)
+    i1 <- match(paste0(res1$read_id, ":", res1$ref_position),
+                paste0(df$read_id, ":", df$ref_position))
+    expect_identical(sum(!is.na(i1)), 11183L)
+    expect_identical(res1$ref_position[!is.na(i1)],
+                     df$ref_position[i1[!is.na(i1)]])
+    
+    # ... content res2
+    expect_identical(res2$read_df$read_id,
+                     c("233e48a7-f379-4dcf-9270-958231125563", "d52a5f6a-a60a-4f85-913e-eada84bfbfb9",
+                       "fc4646ce-66f9-401f-b968-e9b0cda14d61", "92e906ae-cddb-4347-a114-bf9137761a8d",
+                       "6cf74134-e550-4c02-bd2b-91385422ee25", "5d45d8d2-d5f5-47ff-a9fa-f3fd6b7bd3c7",
+                       "b6fea9db-c92d-4152-9d29-4d021bbc45e8", "49c1e21e-8cb0-415a-aba9-92912219c4bb",
+                       "b0b20f04-931f-4f60-b3e4-0ee1f5666a61", "41ca0e97-11b3-454b-9741-bc373e29ef37"))
+    expect_equal(res2$read_df$qscore,
+                 c(14.1428003311157, 16.0126991271973, 21.1338005065918,
+                   20.3082008361816, 16.0568008422852, 13.3486995697021,
+                   13.7178001403809, 12.6245002746582, 16.3353996276855,
+                   13.055100440979))
+    expect_identical(res2$read_df$read_length,
+                     c(20058L, 11305L, 9246L, 12277L, 10041L, 9044L, 9010L, 14736L, 7725L, 7013L))
+    expect_identical(res2$read_df$aligned_length,
+                     c(14801L, 11214L, 9227L, 12227L, 9968L, 8895L, 8891L, 8174L, 7637L, 6895L))
+    expect_identical(res2$read_df$variant_label, rep(NA_character_, 10L))
+    expect_identical(unname(as.vector(table(res2$read_id)[res2$read_df$read_id])),
+                     c(4363L, 3340L, 2925L, 3597L, 3078L,
+                       2720L, 2568L, 2539L, 2412L, 2003L))
+    expect_true(
+        all(paste0(res1$chrom, ":", res1$ref_position, ":", res1$ref_mod_strand) %in%
+                paste0(res2$chrom, ":", res2$ref_position, ":", res2$ref_mod_strand)))
+    for (nm in setdiff(expected_names, "read_df")) {
+        expect_length(res2[[nm]], 29545L)
+    }
+    expect_length(unique(res2$read_id), 10L)
+    i2 <- match(paste0(res2$read_id, ":", res2$ref_position),
+                paste0(df$read_id, ":", df$ref_position))
+    expect_identical(sum(!is.na(i2)), 29104L)
+    expect_identical(res2$ref_position[!is.na(i2)],
+                     df$ref_position[i2[!is.na(i2)]])
+    expect_true(all(
+        res2$call_code[!is.na(i2)] == df$call_code[i2[!is.na(i2)]] |
+            res2$mod_prob[!is.na(i2)] < 0.5))
+    
+    # ... content res3
+    for (nm in setdiff(expected_names, "read_df")) {
+        expect_length(res3[[nm]], 0L)
+    }
+    expect_identical(nrow(res3$read_df), 0L)
+    
+    # ... content of res4
+    # expect_equal(res4, list(
+    #     read_id = rep(c("artificial-read-1", "artificial-read-2"), c(5, 3)),
+    #     ref_position = c(6940001L, 6940008L, 6940012L, 6940015L, 6940019L,
+    #                      6940004L, 6940010L, 6940017L),
+    #     chrom = rep("chr1", 8),
+    #     ref_mod_strand = rep(c("+", "-"), c(5, 3)),
+    #     mod_prob = c(0.134765625, 0.380859375, -1, 0.724609375, 0.998046875,
+    #                  0.318359375, -1, -1),
+    #     read_df = data.frame(read_id = c("artificial-read-1", "artificial-read-2"),
+    #                          qscore = c(13.4761904761905, 13.24),
+    #                          read_length = c(21L, 25L),
+    #                          aligned_length = c(19L, 23L),
+    #                          variant_label = rep(NA_character_, 2L))))
+    
+    # ... content of res5
+    expect_identical(res5, list(
+        chrom = character(0), ref_position = integer(0), 
+        ref_mod_strand = character(0), mod_prob = numeric(0),
+        read_id = character(0), 
+        read_df = data.frame(read_id = character(0), qscore = numeric(0),
+                             read_length = integer(0), aligned_length = integer(0),
+                             variant_label = character(0))))
+    
+    # ... content of res6a and res6b (res6a should be a subset of res6b)
+    # ... ... check ground truth
+    expect_identical(names(aln6a), names(aln6b)[1])
+    expect_identical(aln6a[[1]], aln6b[[1]])
+    expect_length(aln6a[[1]]$qname, 1L)
+    expect_length(intersect(aln6a[[1]]$qname, aln6b[[2]]$qname), 0L)
+    # ... ... check return values
+    expect_true(all(aln6a[[1]]$qname == res6a$read_id))
+    expect_true(aln6b[[1]]$qname %in% res6b$read_id)
+    expect_identical(length(res6a$read_id), sum(aln6b[[1]]$qname == res6b$read_id))
+    expect_identical(res6a$ref_position[res6a$read_id == aln6a[[1]]$qname],
+                     res6b$ref_position[res6b$read_id == aln6b[[1]]$qname])
+    idx <- match(paste(res6a$chrom, res6a$ref_position, res6a$ref_mod_strand, res6a$read_id),
+                 paste(res6b$chrom, res6b$ref_position, res6b$ref_mod_strand, res6b$read_id))
+    expect_true(all(!is.na(idx)))
+    expect_identical(res6a$mod_prob, res6b$mod_prob[idx])
+    expect_equal(res6a$read_df, res6b$read_df[2, , drop = FALSE],
+                 ignore_attr = TRUE)
+})
+
+test_that("pileup_modbam_cpp works by comparing to read_modbam_cpp", {
     # helper function
     get_expected_result <- function(fname, reg, mb = "a", mod_prob_thresh = 0.5,
                                     level = "summary") {

--- a/tests/testthat/test-pileup_modbam_cpp.R
+++ b/tests/testthat/test-pileup_modbam_cpp.R
@@ -1,56 +1,112 @@
 test_that("pileup_modbam_cpp works", {
     # helper function
-    get_expected_result <- function(fname, reg, mb = "a", mod_prob_thresh = 0.5) {
-        read_modbam_cpp(inname_str = fname, regions = reg,
-                        modbase = mb, n_alns_to_sample = 0,
-                        tnames_for_sampling = "chr1",
-                        variantRefNames = character(0),
-                        variantRefPositions = integer(0),
-                        n_threads = 1, verbose = FALSE)[c("chrom", "ref_position",
-                                                          "ref_mod_strand",
-                                                          "mod_prob")] |>
-            as.data.frame() |>
-            dplyr::group_by(chrom, ref_position, ref_mod_strand) |>
-            dplyr::summarise(Nmod = sum(mod_prob >= mod_prob_thresh),
-                             Nvalid = dplyr::n(),
-                             .groups = "drop") |>
-            dplyr::arrange(ref_position, ref_mod_strand) |>
-            as.list()
+    get_expected_result <- function(fname, reg, mb = "a", mod_prob_thresh = 0.5,
+                                    level = "summary") {
+        tmp0 <- read_modbam_cpp(inname_str = fname, regions = reg,
+                                modbase = mb, n_alns_to_sample = 0,
+                                tnames_for_sampling = "chr1",
+                                variantRefNames = character(0),
+                                variantRefPositions = integer(0),
+                                n_threads = 1, verbose = FALSE)
+        tmp <- tmp0[c("chrom", "ref_position", "ref_mod_strand", "mod_prob", 
+                      "read_id")]
+        if (level == "summary") {
+            tmp <- tmp |> 
+                as.data.frame() |>
+                dplyr::group_by(chrom, ref_position, ref_mod_strand) |>
+                dplyr::summarise(Nmod = sum(mod_prob >= mod_prob_thresh),
+                                 Nvalid = dplyr::n(),
+                                 .groups = "drop") |>
+                dplyr::arrange(ref_position, ref_mod_strand)
+        } else {
+            tmp <- tmp |> 
+                as.data.frame() |> 
+                dplyr::arrange(ref_position, read_id, dplyr::desc(ref_mod_strand))
+        }
+        list(lst = as.list(tmp), df = tmp0$read_df)
     }
 
-    # reading all alignments in a bam file
+    # reading all alignments in a bam file (summary)
     # ... expected results
     modbamfile <- system.file("extdata", "6mA_1_10reads.bam", package = "footprintR")
     reg <- "."
     thresh <- 0.7
-    res0 <- get_expected_result(modbamfile, reg, "a", thresh)
+    res0 <- get_expected_result(modbamfile, reg, "a", thresh, level = "summary")
 
     # ... compare to pileup_modbam_cpp return value
     suppressMessages({
         res <- pileup_modbam_cpp(inname_str = modbamfile, regions = reg,
                                  modbase = "a", mod_prob_thresh = thresh,
-                                 n_threads = 1, verbose = TRUE)
+                                 n_threads = 1, verbose = TRUE, level = "summary")
     })
     expect_type(res, "list")
     expect_length(res, 5L)
     expect_named(res, c("chrom", "ref_position", "ref_mod_strand",
                         "Nmod", "Nvalid"))
-    expect_identical(res0, res)
+    expect_identical(res0$lst, res)
+    
+    # reading all alignments in a bam file (read)
+    # ... expected results
+    modbamfile <- system.file("extdata", "6mA_1_10reads.bam", package = "footprintR")
+    reg <- "."
+    thresh <- 0.7
+    res0 <- get_expected_result(modbamfile, reg, "a", thresh, level = "read")
+    
+    # ... compare to pileup_modbam_cpp return value
+    suppressMessages({
+        res <- pileup_modbam_cpp(inname_str = modbamfile, regions = reg,
+                                 modbase = "a", mod_prob_thresh = thresh,
+                                 n_threads = 1, verbose = TRUE, level = "read")
+    })
+    expect_type(res, "list")
+    expect_length(res, 6L)
+    expect_named(res, c("chrom", "ref_position", "ref_mod_strand",
+                        "mod_prob", "read_id", "read_df"))
+    expect_identical(res0$df$read_id, res$read_df$read_id)
+    expect_identical(names(res0$lst), names(res[1:5]))
+    expect_identical(lengths(res0$lst), lengths(res[1:5]))
+    res <- res[1:5] |> 
+        as.data.frame() |> 
+        dplyr::arrange(ref_position, read_id, dplyr::desc(ref_mod_strand)) |> 
+        as.list()
+    expect_identical(res0$lst, res)
 
-    # reading alignments overlapping a region
+    # reading alignments overlapping a region (summary)
     # ... expected results
     modbamfile <- system.file("extdata", "6mA_2_10reads.bam", package = "footprintR")
     reg <- "chr1:6935830-6935830"
     thresh <- 0.3
-    res0 <- get_expected_result(modbamfile, reg, "a", thresh)
+    res0 <- get_expected_result(modbamfile, reg, "a", thresh, "summary")
 
     # ... compare to pileup_modbam_cpp return value
     res <- pileup_modbam_cpp(inname_str = modbamfile, regions = reg,
                              modbase = "a", mod_prob_thresh = thresh,
-                             n_threads = 1, verbose = FALSE)
+                             n_threads = 1, verbose = FALSE, level = "summary")
     expect_type(res, "list")
     expect_length(res, 5L)
     expect_named(res, c("chrom", "ref_position", "ref_mod_strand",
                         "Nmod", "Nvalid"))
-    expect_identical(res0, res)
+    expect_identical(res0$lst, res)
+    
+    # reading alignments overlapping a region (read)
+    # ... expected results
+    modbamfile <- system.file("extdata", "6mA_2_10reads.bam", package = "footprintR")
+    reg <- "chr1:6935830-6935830"
+    thresh <- 0.3
+    res0 <- get_expected_result(modbamfile, reg, "a", thresh, "read")
+    
+    # ... compare to pileup_modbam_cpp return value
+    res <- pileup_modbam_cpp(inname_str = modbamfile, regions = reg,
+                             modbase = "a", mod_prob_thresh = thresh,
+                             n_threads = 1, verbose = FALSE, level = "read")
+    expect_type(res, "list")
+    expect_length(res, 6L)
+    expect_named(res, c("chrom", "ref_position", "ref_mod_strand",
+                        "mod_prob", "read_id", "read_df"))
+    expect_identical(res0$df$read_id, res$read_df$read_id)
+    res <- res[1:5] |> 
+        as.data.frame() |> 
+        dplyr::arrange(ref_position, read_id, dplyr::desc(ref_mod_strand)) |> 
+        as.list()
+    expect_identical(res0$lst, res)
 })

--- a/tests/testthat/test-pileup_modbam_cpp.R
+++ b/tests/testthat/test-pileup_modbam_cpp.R
@@ -59,11 +59,11 @@ test_that("pileup_modbam_cpp works", {
                               n_threads = 1, 
                               verbose = FALSE)
     # ... crashes
-    # res4 <- pileup_modbam_cpp(inname_str = bam4,
-    #                           regions = "chr1",
-    #                           modbase = "a", level = "read",
-    #                           n_threads = 1,
-    #                           verbose = FALSE)
+    res4 <- pileup_modbam_cpp(inname_str = bam4,
+                              regions = "chr1",
+                              modbase = "a", level = "read",
+                              n_threads = 1,
+                              verbose = FALSE)
     res5 <- pileup_modbam_cpp(inname_str = bam5, 
                               regions = "chr1", 
                               modbase = "a", level = "read",
@@ -94,7 +94,7 @@ test_that("pileup_modbam_cpp works", {
     expect_type(res1, "list")
     expect_type(res2, "list")
     expect_type(res3, "list")
-    # expect_type(res4, "list")
+    expect_type(res4, "list")
     expect_type(res5, "list")
     expect_type(res6a, "list")
     expect_type(res6b, "list")
@@ -104,7 +104,7 @@ test_that("pileup_modbam_cpp works", {
     expect_named(res1, expected_names)
     expect_named(res2, expected_names)
     expect_named(res3, expected_names)
-    # expect_named(res4, expected_names)
+    expect_named(res4, expected_names)
     expect_named(res5, expected_names)
     expect_named(res6a, expected_names)
     expect_named(res6b, expected_names)
@@ -116,7 +116,7 @@ test_that("pileup_modbam_cpp works", {
         expect_type(res1[[expected_names[i]]], expected_types[i])
         expect_type(res2[[expected_names[i]]], expected_types[i])
         expect_type(res3[[expected_names[i]]], expected_types[i])
-        # expect_type(res4[[expected_names[i]]], expected_types[i])
+        expect_type(res4[[expected_names[i]]], expected_types[i])
         expect_type(res5[[expected_names[i]]], expected_types[i])
         expect_type(res6a[[expected_names[i]]], expected_types[i])
         expect_type(res6b[[expected_names[i]]], expected_types[i])
@@ -125,7 +125,7 @@ test_that("pileup_modbam_cpp works", {
     expect_s3_class(res1[["read_df"]], "data.frame")
     expect_s3_class(res2[["read_df"]], "data.frame")
     expect_s3_class(res3[["read_df"]], "data.frame")
-    # expect_s3_class(res4[["read_df"]], "data.frame")
+    expect_s3_class(res4[["read_df"]], "data.frame")
     expect_s3_class(res5[["read_df"]], "data.frame")
     expect_s3_class(res6a[["read_df"]], "data.frame")
     expect_s3_class(res6b[["read_df"]], "data.frame")
@@ -134,7 +134,7 @@ test_that("pileup_modbam_cpp works", {
     expect_named(res1$read_df, expected_df_colnames)
     expect_named(res2$read_df, expected_df_colnames)
     expect_named(res3$read_df, expected_df_colnames)
-    # expect_named(res4$read_df, expected_df_colnames)
+    expect_named(res4$read_df, expected_df_colnames)
     expect_named(res5$read_df, expected_df_colnames)
     expect_named(res6a$read_df, expected_df_colnames)
     expect_named(res6b$read_df, expected_df_colnames)
@@ -205,19 +205,21 @@ test_that("pileup_modbam_cpp works", {
     expect_identical(nrow(res3$read_df), 0L)
     
     # ... content of res4
-    # expect_equal(res4, list(
-    #     read_id = rep(c("artificial-read-1", "artificial-read-2"), c(5, 3)),
-    #     ref_position = c(6940001L, 6940008L, 6940012L, 6940015L, 6940019L,
-    #                      6940004L, 6940010L, 6940017L),
-    #     chrom = rep("chr1", 8),
-    #     ref_mod_strand = rep(c("+", "-"), c(5, 3)),
-    #     mod_prob = c(0.134765625, 0.380859375, -1, 0.724609375, 0.998046875,
-    #                  0.318359375, -1, -1),
-    #     read_df = data.frame(read_id = c("artificial-read-1", "artificial-read-2"),
-    #                          qscore = c(13.4761904761905, 13.24),
-    #                          read_length = c(21L, 25L),
-    #                          aligned_length = c(19L, 23L),
-    #                          variant_label = rep(NA_character_, 2L))))
+    expect_equal(res4, list(
+        chrom = rep("chr1", 8),
+        ref_position = c(6940001L, 6940004L, 6940008L, 6940010L, 6940012L, 
+                         6940015L, 6940017L, 6940019L),
+        ref_mod_strand = c("+", "-", "+", "-", "+", "+", "-", "+"),
+        mod_prob = c(0.134765625, 0.318359375, 0.380859375, -1, -1, 
+                     0.724609375, -1, 0.998046875),
+        read_id = c("artificial-read-1", "artificial-read-2", "artificial-read-1", 
+                    "artificial-read-2", "artificial-read-1", "artificial-read-1", 
+                    "artificial-read-2", "artificial-read-1"),
+        read_df = data.frame(read_id = c("artificial-read-1", "artificial-read-2"),
+                             qscore = c(13.4761904761905, 13.24),
+                             read_length = c(21L, 25L),
+                             aligned_length = c(19L, 23L),
+                             variant_label = rep(NA_character_, 2L))))
     
     # ... content of res5
     expect_identical(res5, list(

--- a/tests/testthat/test-pileup_modbam_cpp.R
+++ b/tests/testthat/test-pileup_modbam_cpp.R
@@ -32,10 +32,9 @@ test_that("pileup_modbam_cpp works", {
                  "Failed to get bam iterator")
     
     # ... too many modifications on a single base
-    # ... crashes
-    # expect_error(pileup_modbam_cpp(inname_str = bam8, regions = "chr1",
-    #                                modbase = "a", verbose = FALSE),
-    #              "More modifications than footprintR")
+    expect_error(pileup_modbam_cpp(inname_str = bam8, regions = "chr1",
+                                   modbase = "a", verbose = FALSE),
+                 "More modifications than footprintR")
     
     ## expected results --------------------------------------------------------
     # ... run pileup_modbam_cpp

--- a/tests/testthat/test-pileup_modbam_cpp.R
+++ b/tests/testthat/test-pileup_modbam_cpp.R
@@ -57,7 +57,6 @@ test_that("pileup_modbam_cpp works", {
                               modbase = "m", level = "read",
                               n_threads = 1, 
                               verbose = FALSE)
-    # ... crashes
     res4 <- pileup_modbam_cpp(inname_str = bam4,
                               regions = "chr1",
                               modbase = "a", level = "read",
@@ -201,7 +200,9 @@ test_that("pileup_modbam_cpp works", {
     for (nm in setdiff(expected_names, "read_df")) {
         expect_length(res3[[nm]], 0L)
     }
-    expect_identical(nrow(res3$read_df), 0L)
+    ## This will still contain all reads - will be filtered out in the 
+    ## readModBam R wrapper
+    expect_identical(nrow(res3$read_df), 10L)
     
     # ... content of res4
     expect_equal(res4, list(

--- a/tests/testthat/test-readModBam.R
+++ b/tests/testthat/test-readModBam.R
@@ -147,6 +147,11 @@ test_that("readModBam works", {
                          sequenceContextWidth = 1, sequenceReference = ref,
                          seqnamesToSampleFrom = "chr1", verbose = FALSE,
                          BPPARAM = BiocParallel::SerialParam())
+    se1quick <- readModBam(bamfiles = modbamfiles, regions = reg1,
+                           modbase = "a", level = "quickread", nAlnsToSample = 0,
+                           sequenceContextWidth = 1, sequenceReference = ref,
+                           seqnamesToSampleFrom = "chr1", verbose = FALSE,
+                           BPPARAM = BiocParallel::SerialParam())
     se2 <- readModBam(bamfiles = unname(modbamfiles),
                       regions = reg2,
                       modbase = "a",
@@ -159,6 +164,12 @@ test_that("readModBam works", {
                          nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                          BPPARAM = BiocParallel::MulticoreParam(workers = 2L),
                          verbose = FALSE)
+    se2quick <- readModBam(bamfiles = unname(modbamfiles),
+                           regions = reg2,
+                           modbase = "a", level = "quickread",
+                           nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
+                           BPPARAM = BiocParallel::MulticoreParam(workers = 2L),
+                           verbose = FALSE)
     se3 <- readModBam(bamfiles = modbamfiles,
                       regions = reg3,
                       modbase = "a",
@@ -171,6 +182,12 @@ test_that("readModBam works", {
                          nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                          BPPARAM = BiocParallel::SerialParam(),
                          verbose = FALSE)
+    se3quick <- readModBam(bamfiles = modbamfiles,
+                           regions = reg3,
+                           modbase = "a", level = "quickread",
+                           nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
+                           BPPARAM = BiocParallel::SerialParam(),
+                           verbose = FALSE)
     se4 <- readModBam(bamfiles = modbamfiles,
                       regions = reg4,
                       modbase = c("a", "m"),
@@ -183,6 +200,12 @@ test_that("readModBam works", {
                          nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
                          BPPARAM = BiocParallel::SerialParam(),
                          verbose = FALSE)
+    se4quick <- readModBam(bamfiles = modbamfiles,
+                           regions = reg4, level = "quickread",
+                           modbase = c("a", "m"),
+                           nAlnsToSample = 0, seqnamesToSampleFrom = "chr1",
+                           BPPARAM = BiocParallel::SerialParam(),
+                           verbose = FALSE)
     se5a <- readModBam(bamfiles = modbamfiles[1],
                        regions = reg5[1],
                        modbase = "a",
@@ -236,6 +259,12 @@ test_that("readModBam works", {
                           sampleAnnot = sample_annot,
                           BPPARAM = BiocParallel::SerialParam(RNGseed = 55L),
                           verbose = FALSE)
+    se7quick  <- readModBam(bamfiles = modbamfiles,
+                            regions = reg5[1:2],
+                            modbase = "a", level = "quickread",
+                            sampleAnnot = sample_annot,
+                            BPPARAM = BiocParallel::SerialParam(RNGseed = 55L),
+                            verbose = FALSE)
     se8 <- readModBam(bamfiles = modbamfiles,
                       regions = reg1,
                       modbase = "a",
@@ -246,15 +275,22 @@ test_that("readModBam works", {
                          modbase = "a", level = "summary",
                          BPPARAM = BiocParallel::SerialParam(RNGseed = 55L),
                          trim = TRUE, verbose = FALSE)
+    se8quick <- readModBam(bamfiles = modbamfiles,
+                           regions = reg1,
+                           modbase = "a", level = "quickread",
+                           BPPARAM = BiocParallel::SerialParam(RNGseed = 55L),
+                           trim = TRUE, verbose = FALSE)
 
     seL <- list(se1, se2, se3, se4, se5a, se5b, se6a, se6b, se8)
     seLsum <- list(se1sum, se2sum, se3sum, se4sum, se8sum)
+    seLquick <- list(se1quick, se2quick, se3quick, se4quick, se8quick)
 
     # ... structure
     expected_coldata_names <- c("sample", "modbase", "n_reads", "readInfo")
     expected_coldata_names_summary <- c("sample", "modbase")
     expected_read_info_names <- c("qscore", "read_length", "aligned_length",
                                   "variant_label", "aligned_fraction")
+    expected_read_info_names_quick <- c("aligned_fraction")
     for (se in c(seL, list(se7))) {
         expect_s4_class(se, "RangedSummarizedExperiment")
         expect_s4_class(rowRanges(se), "GPos")
@@ -287,22 +323,49 @@ test_that("readModBam works", {
     expect_identical(colnames(colData(se7sum)), c(expected_coldata_names_summary,
                                                   "group", "condition"))
 
+    ## ... ... quick-read
+    for (se in c(seLquick, list(se7quick))) {
+        expect_s4_class(se, "RangedSummarizedExperiment")
+        expect_s4_class(rowRanges(se), "GPos")
+        expect_s4_class(colData(se)$readInfo, "SimpleList")
+        res_se <- lapply(colData(se)$readInfo, function(df) {
+            expect_s4_class(df, "DataFrame")
+            expect_named(df, expected_read_info_names_quick)
+        })
+        expect_identical(assayNames(se), "mod_prob")
+        expect_s4_class(assay(se, "mod_prob"), "DFrame")
+        expect_s4_class(assay(se, "mod_prob")[[1]], "NaMatrix")
+        expect_equal(vapply(assay(se, "mod_prob"), ncol, 0), se$n_reads,
+                     ignore_attr = TRUE)
+    }
+    for (se in seLquick) {
+        expect_identical(colnames(colData(se)), expected_coldata_names)
+    }
+    expect_identical(colnames(colData(se7quick)), c(expected_coldata_names,
+                                                    "group", "condition"))
+    
     expect_identical(colnames(se1), names(modbamfiles))
     expect_identical(colnames(se1sum), names(modbamfiles))
+    expect_identical(colnames(se1quick), names(modbamfiles))
     expect_identical(colnames(se2), c("s1", "s2"))
     expect_identical(colnames(se2sum), c("s1", "s2"))
+    expect_identical(colnames(se2quick), c("s1", "s2"))
     expect_identical(colnames(se3), names(modbamfiles))
     expect_identical(colnames(se3sum), names(modbamfiles))
+    expect_identical(colnames(se3quick), names(modbamfiles))
     expect_identical(colnames(se4), names(modbamfiles))
     expect_identical(colnames(se4sum), names(modbamfiles))
+    expect_identical(colnames(se4quick), names(modbamfiles))
     expect_identical(colnames(se5a), names(modbamfiles)[1])
     expect_identical(colnames(se5b), names(modbamfiles)[1])
     expect_identical(colnames(se6a), names(modbamfiles)[1])
     expect_identical(colnames(se6b), names(modbamfiles)[1])
     expect_identical(colnames(se7), names(modbamfiles))
     expect_identical(colnames(se7sum), names(modbamfiles))
+    expect_identical(colnames(se7quick), names(modbamfiles))
     expect_identical(colnames(se8), names(modbamfiles))
     expect_identical(colnames(se8sum), names(modbamfiles))
+    expect_identical(colnames(se8quick), names(modbamfiles))
     
     # ... content se1
     expect_identical(unname(se1$n_reads), c(4L, 6L))
@@ -353,6 +416,18 @@ test_that("readModBam works", {
     expect_identical(colData(se1)[, c("sample", "modbase")],
                      colData(se1sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se1), rowRanges(se1sum))
+    # ... compare to se1quick
+    expect_identical(rownames(se1), rownames(se1quick))
+    expect_identical(rowRanges(se1), rowRanges(se1quick))
+    ## in principle, there is no guarantee that the reads have to be in the 
+    ## same order (but here they are)
+    expect_identical(assay(se1, "mod_prob"), 
+                     assay(se1quick, "mod_prob"))
+    expect_identical(metadata(se1), metadata(se1quick))
+    expect_identical(colData(se1)[, c("sample", "modbase", "n_reads")],
+                     colData(se1quick)[, c("sample", "modbase", "n_reads")])
+    expect_identical(rownames(colData(se1)$readInfo$sample1),
+                     rownames(colData(se1quick)$readInfo$sample1))
     
     # ... content se2
     expect_identical(unname(se2$n_reads), c(3L, 2L))
@@ -375,6 +450,18 @@ test_that("readModBam works", {
     expect_identical(colData(se2)[, c("sample", "modbase")],
                      colData(se2sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se2), rowRanges(se2sum))
+    # ... compare to se2quick
+    expect_identical(rownames(se2), rownames(se2quick))
+    expect_identical(rowRanges(se2), rowRanges(se2quick))
+    ## in principle, there is no guarantee that the reads have to be in the 
+    ## same order (but here they are)
+    expect_identical(assay(se2, "mod_prob"), 
+                     assay(se2quick, "mod_prob"))
+    expect_identical(metadata(se2), metadata(se2quick))
+    expect_identical(colData(se2)[, c("sample", "modbase", "n_reads")],
+                     colData(se2quick)[, c("sample", "modbase", "n_reads")])
+    expect_identical(rownames(colData(se2)$readInfo$sample1),
+                     rownames(colData(se2quick)$readInfo$sample1))
     
     # ... content se3
     expect_identical(unname(se3$n_reads), c(3L, 2L))
@@ -416,6 +503,18 @@ test_that("readModBam works", {
     expect_identical(colData(se3)[, c("sample", "modbase")],
                      colData(se3sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se3), rowRanges(se3sum))
+    # ... compare to se3quick
+    expect_identical(rownames(se3), rownames(se3quick))
+    expect_identical(rowRanges(se3), rowRanges(se3quick))
+    ## in principle, there is no guarantee that the reads have to be in the 
+    ## same order (but here they are)
+    expect_identical(assay(se3, "mod_prob"), 
+                     assay(se3quick, "mod_prob"))
+    expect_identical(metadata(se3), metadata(se3quick))
+    expect_identical(colData(se3)[, c("sample", "modbase", "n_reads")],
+                     colData(se3quick)[, c("sample", "modbase", "n_reads")])
+    expect_identical(rownames(colData(se3)$readInfo$sample1),
+                     rownames(colData(se3quick)$readInfo$sample1))
     
     # ... content se4
     expect_identical(unname(se4$n_reads), c(3L, 0L))
@@ -446,6 +545,18 @@ test_that("readModBam works", {
     expect_identical(colData(se4)[, c("sample", "modbase")],
                      colData(se4sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se4), rowRanges(se4sum))
+    # ... compare to se4quick
+    expect_identical(rownames(se4), rownames(se4quick))
+    expect_identical(rowRanges(se4), rowRanges(se4quick))
+    ## in principle, there is no guarantee that the reads have to be in the 
+    ## same order (but here they are)
+    expect_identical(assay(se4, "mod_prob"), 
+                     assay(se4quick, "mod_prob"))
+    expect_identical(metadata(se4), metadata(se4quick))
+    expect_identical(colData(se4)[, c("sample", "modbase", "n_reads")],
+                     colData(se4quick)[, c("sample", "modbase", "n_reads")])
+    expect_identical(rownames(colData(se4)$readInfo$sample1),
+                     rownames(colData(se4quick)$readInfo$sample1))
     
     # ... content of se5a and se5b (se5a should be a subset of se5b)
     # ... ... check ground truth
@@ -482,6 +593,18 @@ test_that("readModBam works", {
     expect_identical(colData(se7)[, c("sample", "modbase")],
                      colData(se7sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se7), rowRanges(se7sum))
+    # ... compare to se7quick
+    expect_identical(rownames(se7), rownames(se7quick))
+    expect_identical(rowRanges(se7), rowRanges(se7quick))
+    ## in principle, there is no guarantee that the reads have to be in the 
+    ## same order (but here they are)
+    expect_identical(assay(se7, "mod_prob"), 
+                     assay(se7quick, "mod_prob"))
+    expect_identical(metadata(se7), metadata(se7quick))
+    expect_identical(colData(se7)[, c("sample", "modbase", "n_reads")],
+                     colData(se7quick)[, c("sample", "modbase", "n_reads")])
+    expect_identical(rownames(colData(se7)$readInfo$sample1),
+                     rownames(colData(se7quick)$readInfo$sample1))
 
     # ... content of se8 (like se1, but trimmed)
     expect_identical(unname(se8$n_reads), c(4L, 6L))
@@ -506,6 +629,18 @@ test_that("readModBam works", {
     expect_identical(colData(se8)[, c("sample", "modbase")],
                      colData(se8sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se8), rowRanges(se8sum))
+    # ... compare to se8quick
+    expect_identical(rownames(se8), rownames(se8quick))
+    expect_identical(rowRanges(se8), rowRanges(se8quick))
+    ## in principle, there is no guarantee that the reads have to be in the 
+    ## same order (but here they are)
+    expect_identical(assay(se8, "mod_prob"), 
+                     assay(se8quick, "mod_prob"))
+    expect_identical(metadata(se8), metadata(se8quick))
+    expect_identical(colData(se8)[, c("sample", "modbase", "n_reads")],
+                     colData(se8quick)[, c("sample", "modbase", "n_reads")])
+    expect_identical(rownames(colData(se8)$readInfo$sample1),
+                     rownames(colData(se8quick)$readInfo$sample1))
 })
 
 test_that("readModBam correctly labels reads", {

--- a/tests/testthat/test-readModBam.R
+++ b/tests/testthat/test-readModBam.R
@@ -290,8 +290,7 @@ test_that("readModBam works", {
     expected_coldata_names_summary <- c("sample", "modbase")
     expected_read_info_names <- c("qscore", "read_length", "aligned_length",
                                   "variant_label", "aligned_fraction")
-    expected_read_info_names_quick <- c("aligned_fraction")
-    for (se in c(seL, list(se7))) {
+    for (se in c(seL, list(se7), seLquick, list(se7quick))) {
         expect_s4_class(se, "RangedSummarizedExperiment")
         expect_s4_class(rowRanges(se), "GPos")
         expect_s4_class(colData(se)$readInfo, "SimpleList")
@@ -305,11 +304,13 @@ test_that("readModBam works", {
         expect_equal(vapply(assay(se, "mod_prob"), ncol, 0), se$n_reads,
                      ignore_attr = TRUE)
     }
-    for (se in seL) {
+    for (se in c(seL, seLquick)) {
         expect_identical(colnames(colData(se)), expected_coldata_names)
     }
     expect_identical(colnames(colData(se7)), c(expected_coldata_names,
                                                "group", "condition"))
+    expect_identical(colnames(colData(se7quick)), c(expected_coldata_names,
+                                                    "group", "condition"))
     ## ... ... summary-level
     for (se in c(seLsum, list(se7sum))) {
         expect_s4_class(se, "RangedSummarizedExperiment")
@@ -323,27 +324,6 @@ test_that("readModBam works", {
     expect_identical(colnames(colData(se7sum)), c(expected_coldata_names_summary,
                                                   "group", "condition"))
 
-    ## ... ... quick-read
-    for (se in c(seLquick, list(se7quick))) {
-        expect_s4_class(se, "RangedSummarizedExperiment")
-        expect_s4_class(rowRanges(se), "GPos")
-        expect_s4_class(colData(se)$readInfo, "SimpleList")
-        res_se <- lapply(colData(se)$readInfo, function(df) {
-            expect_s4_class(df, "DataFrame")
-            expect_named(df, expected_read_info_names_quick)
-        })
-        expect_identical(assayNames(se), "mod_prob")
-        expect_s4_class(assay(se, "mod_prob"), "DFrame")
-        expect_s4_class(assay(se, "mod_prob")[[1]], "NaMatrix")
-        expect_equal(vapply(assay(se, "mod_prob"), ncol, 0), se$n_reads,
-                     ignore_attr = TRUE)
-    }
-    for (se in seLquick) {
-        expect_identical(colnames(colData(se)), expected_coldata_names)
-    }
-    expect_identical(colnames(colData(se7quick)), c(expected_coldata_names,
-                                                    "group", "condition"))
-    
     expect_identical(colnames(se1), names(modbamfiles))
     expect_identical(colnames(se1sum), names(modbamfiles))
     expect_identical(colnames(se1quick), names(modbamfiles))
@@ -417,6 +397,7 @@ test_that("readModBam works", {
                      colData(se1sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se1), rowRanges(se1sum))
     # ... compare to se1quick
+    expect_identical(se1, se1quick)
     expect_identical(rownames(se1), rownames(se1quick))
     expect_identical(rowRanges(se1), rowRanges(se1quick))
     ## in principle, there is no guarantee that the reads have to be in the 
@@ -451,6 +432,7 @@ test_that("readModBam works", {
                      colData(se2sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se2), rowRanges(se2sum))
     # ... compare to se2quick
+    expect_identical(se2, se2quick)
     expect_identical(rownames(se2), rownames(se2quick))
     expect_identical(rowRanges(se2), rowRanges(se2quick))
     ## in principle, there is no guarantee that the reads have to be in the 
@@ -504,6 +486,7 @@ test_that("readModBam works", {
                      colData(se3sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se3), rowRanges(se3sum))
     # ... compare to se3quick
+    expect_identical(se3, se3quick)
     expect_identical(rownames(se3), rownames(se3quick))
     expect_identical(rowRanges(se3), rowRanges(se3quick))
     ## in principle, there is no guarantee that the reads have to be in the 
@@ -546,6 +529,7 @@ test_that("readModBam works", {
                      colData(se4sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se4), rowRanges(se4sum))
     # ... compare to se4quick
+    expect_identical(se4, se4quick)
     expect_identical(rownames(se4), rownames(se4quick))
     expect_identical(rowRanges(se4), rowRanges(se4quick))
     ## in principle, there is no guarantee that the reads have to be in the 
@@ -594,6 +578,7 @@ test_that("readModBam works", {
                      colData(se7sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se7), rowRanges(se7sum))
     # ... compare to se7quick
+    expect_identical(se7, se7quick)
     expect_identical(rownames(se7), rownames(se7quick))
     expect_identical(rowRanges(se7), rowRanges(se7quick))
     ## in principle, there is no guarantee that the reads have to be in the 
@@ -630,6 +615,7 @@ test_that("readModBam works", {
                      colData(se8sum)[, c("sample", "modbase")])
     expect_identical(rowRanges(se8), rowRanges(se8sum))
     # ... compare to se8quick
+    expect_identical(se8, se8quick)
     expect_identical(rownames(se8), rownames(se8quick))
     expect_identical(rowRanges(se8), rowRanges(se8quick))
     ## in principle, there is no guarantee that the reads have to be in the 


### PR DESCRIPTION
Extension to the `pileup` branch, allowing to get also read-level data from the pileup. This is faster than reading all alignment records, but doesn't support read sampling and currently doesn't return all annotations provided by `readModBam` (missing the variant label).